### PR TITLE
ci: release without repo secrets via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,14 @@ jobs:
   code:
     uses: clibuilder/.github/.github/workflows/pnpm-verify.yml@main
 
+  # Secretless: GITHUB_TOKEN for the version PR, npm trusted publishing (OIDC) to
+  # publish. No CI_GITHUB_TOKEN or NPM_TOKEN, so nothing to rotate. npm validates the
+  # caller workflow, so the trusted publisher is registered against this file rather
+  # than the reusable one, and `id-token: write` is granted here as well as in the callee.
   release:
     uses: clibuilder/.github/.github/workflows/pnpm-release-changeset.yml@main
     needs: code
-    secrets: inherit
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
Follows `cyberuni/.github` and `unional/search-packages`: the reusable `pnpm-release-changeset` workflow in `clibuilder/.github` is now secretless, so this caller stops inheriting secrets and grants the token permissions instead.

- `GITHUB_TOKEN` with elevated `permissions` replaces `CI_GITHUB_TOKEN`. The version PR loses its status checks in exchange — fine for a mechanical version + changelog bump gated behind a verified main.
- npm trusted publishing (OIDC) replaces `NPM_TOKEN`, and adds provenance attestations.

npm validates the *caller* workflow, so the trusted publisher must be registered at npmjs.com/package/clibuilder/access against `clibuilder/clibuilder` + `release.yml` before the next release, and `id-token: write` is granted here as well as in the callee.

Org and repo setting "Allow GitHub Actions to create and approve pull requests" is now enabled; default workflow permissions stay read-only since the workflow requests what it needs explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)