### PR TITLE
ci: modernize codeql and pass the codecov token explicitly

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,3 +6,5 @@ on:
 jobs:
   code:
     uses: clibuilder/.github/.github/workflows/pnpm-verify.yml@main
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   code:
     uses: clibuilder/.github/.github/workflows/pnpm-verify.yml@main
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # Secretless: GITHUB_TOKEN for the version PR, npm trusted publishing (OIDC) to
   # publish. No CI_GITHUB_TOKEN or NPM_TOKEN, so nothing to rotate. npm validates the


### PR DESCRIPTION
Follow-up to #558, bringing the verify path up to the same footing as the release path. The shared half landed in [clibuilder/.github@27acc66](https://github.com/clibuilder/.github/commit/27acc66); this is the caller half.

**Shared (`clibuilder/.github`)**
- checkout/setup-node v3 → v7, codecov-action v3 → v7, codeql-action v2 → v4, pnpm/action-setup v2 → v6.
- Dropped the `pnpm-version: 8.14.1` default in favour of `packageManager` — the pin disagreed with this repo's pnpm 10 lockfile.
- Node matrix `[16, 18, 20]` → `[18, 22, 24]`. Node 16 is long EOL and below `engines.node: >= 18`; 24 is what `.node-version` pins.
- Coverage upload was gated on `node-version == 20`, which the new matrix would never match — now a `codecov-node-version` input defaulting to 24.

**Here**
- Both callers pass `CODECOV_TOKEN` explicitly (declared as an optional secret upstream), so coverage keeps uploading without inheriting the whole secret scope.
- Local codeql: checkout v4 → v7 (digest-pinned, matching `unional/search-packages`), codeql-action v3 → v4.

`main`'s required status checks were updated to the new context names (`… , 18 / 22 / 24`) — the old `(…, 20)` contexts no longer exist and would have blocked every PR including #553.

🤖 Generated with [Claude Code](https://claude.com/claude-code)