### PR TITLE
fix: drop the missing lint task from clibuilder's verify script

### DIFF
--- a/packages/clibuilder/package.json
+++ b/packages/clibuilder/package.json
@@ -58,7 +58,7 @@
 		"depcheck": "depcheck",
 		"nuke": "run-s clean && rimraf node_modules",
 		"test": "cross-env NODE_OPTIONS=--experimental-vm-modules NODE_NO_WARNINGS=1 jest",
-		"verify": "npm-run-all clean -p build lint coverage depcheck",
+		"verify": "npm-run-all clean -p build coverage depcheck",
 		"watch": "cross-env NODE_OPTIONS=--experimental-vm-modules NODE_NO_WARNINGS=1 jest --watch",
 		"w": "pnpm watch"
 	},


### PR DESCRIPTION
`pnpm verify` inside `packages/clibuilder` failed with `Task not found: "lint"`.

Linting is a root-level biome task — the root `verify` runs `run-p lint verify:pkg` across the workspace, and `args-minus` defines no lint of its own — so the package script referenced a task that never existed there. CI runs the root task, which is why this stayed invisible.

Verified: `pnpm verify` now completes inside the package (build, coverage, depcheck; 230 tests passing). Lint coverage is unchanged, since the root task already covers this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)