### PR TITLE
fix: render optional and variadic arguments correctly in help

### DIFF
--- a/.changeset/eighty-poems-jam.md
+++ b/.changeset/eighty-poems-jam.md
@@ -1,0 +1,17 @@
+---
+'clibuilder': patch
+---
+
+Fix optional and variadic arguments in the help output.
+
+The `Arguments:` section tested the `isOptional` *method* instead of calling it, so a typed required
+argument rendered as `[name]` and an optional one as `<name>`, exactly backwards. Arguments now use
+the same notation as options: `<name>` when required, `[name]` when optional, with the declared type
+(`=string`, `=number`, `=boolean`) and a `...` variadic marker.
+
+```
+Arguments:
+  <src=string>           the source
+  [host=string]          the host
+  <files=string...>      the files
+```

--- a/apps/website/src/content/docs/api/ui.md
+++ b/apps/website/src/content/docs/api/ui.md
@@ -68,7 +68,7 @@ and its options — you never write it by hand. It is printed automatically when
 Usage: app <arguments> [options]
 
 Arguments:
-  [values]               values to add
+  <values=number...>     values to add
 
 Options:
   [-h|--help]            Print help message
@@ -77,6 +77,18 @@ Options:
   [--silent]             Turn off logging
   [--debug-cli]          Display clibuilder debug messages
 ```
+
+Arguments and options are written in the same notation:
+
+| Notation | Meaning |
+| --- | --- |
+| `<name>` | Required |
+| `[name]` | Optional — declared with `z.optional(...)` |
+| `=string`, `=number`, `=boolean` | The declared type, when there is one |
+| `...` | Variadic — declared with `z.array(...)` |
+
+A boolean option is a flag, so it shows as `[--flag]` rather than `[--flag=boolean]`. An option with
+no declared type is a flag too, and an argument with no declared type is a required string.
 
 Calling it yourself is the right move when a command detects an input problem it can't express in a
 schema:

--- a/packages/clibuilder/ts/ui.spec.ts
+++ b/packages/clibuilder/ts/ui.spec.ts
@@ -81,39 +81,132 @@ Commands:
 repo <command> -h        Get help for <command>
 `)
 	})
-	test('required argument', () => {
-		const { ui, reporter } = testUI()
-		ui.showHelp(
-			'cli',
-			command({
-				name: 'cmd',
-				arguments: [{ name: 'x', description: '' }],
-				run() {}
-			})
-		)
-		expect(reporter.getLogMessage()).toEqual(`
+	describe('arguments', () => {
+		test('untyped argument is required', () => {
+			const { ui, reporter } = testUI()
+			ui.showHelp(
+				'cli',
+				command({
+					name: 'cmd',
+					arguments: [{ name: 'x', description: '' }],
+					run() {}
+				})
+			)
+			expect(reporter.getLogMessage()).toEqual(`
 Usage: cli cmd <arguments>
 
 Arguments:
   <x>
 `)
-	})
-	test('optional argument', () => {
-		const { ui, reporter } = testUI()
-		ui.showHelp(
-			'cli',
-			command({
-				name: 'cmd',
-				arguments: [{ name: 'x', description: '', type: z.optional(z.string()) }],
-				run() {}
-			})
-		)
-		expect(reporter.getLogMessage()).toEqual(`
+		})
+		test('required argument', () => {
+			const { ui, reporter } = testUI()
+			ui.showHelp(
+				'cli',
+				command({
+					name: 'cmd',
+					arguments: [{ name: 'x', description: '', type: z.string() }],
+					run() {}
+				})
+			)
+			expect(reporter.getLogMessage()).toEqual(`
+Usage: cli cmd <arguments>
+
+Arguments:
+  <x=string>
+`)
+		})
+		test('optional argument', () => {
+			const { ui, reporter } = testUI()
+			ui.showHelp(
+				'cli',
+				command({
+					name: 'cmd',
+					arguments: [{ name: 'x', description: '', type: z.optional(z.string()) }],
+					run() {}
+				})
+			)
+			expect(reporter.getLogMessage()).toEqual(`
 Usage: cli cmd [arguments]
 
 Arguments:
-  [x]
+  [x=string]
 `)
+		})
+		test('variadic argument', () => {
+			const { ui, reporter } = testUI()
+			ui.showHelp(
+				'cli',
+				command({
+					name: 'cmd',
+					arguments: [{ name: 'x', description: '', type: z.array(z.string()) }],
+					run() {}
+				})
+			)
+			expect(reporter.getLogMessage()).toEqual(`
+Usage: cli cmd <arguments>
+
+Arguments:
+  <x=string...>
+`)
+		})
+		test('optional variadic argument', () => {
+			const { ui, reporter } = testUI()
+			ui.showHelp(
+				'cli',
+				command({
+					name: 'cmd',
+					arguments: [{ name: 'x', description: '', type: z.optional(z.array(z.number())) }],
+					run() {}
+				})
+			)
+			expect(reporter.getLogMessage()).toEqual(`
+Usage: cli cmd [arguments]
+
+Arguments:
+  [x=number...]
+`)
+		})
+		test('boolean argument shows its type', () => {
+			const { ui, reporter } = testUI()
+			ui.showHelp(
+				'cli',
+				command({
+					name: 'cmd',
+					arguments: [{ name: 'x', description: '', type: z.boolean() }],
+					run() {}
+				})
+			)
+			expect(reporter.getLogMessage()).toEqual(`
+Usage: cli cmd <arguments>
+
+Arguments:
+  <x=boolean>
+`)
+		})
+		test('required, optional, and variadic arguments together', () => {
+			const { ui, reporter } = testUI()
+			ui.showHelp(
+				'cli',
+				command({
+					name: 'cmd',
+					arguments: [
+						{ name: 'src', description: 'the source', type: z.string() },
+						{ name: 'host', description: 'the host', type: z.optional(z.string()) },
+						{ name: 'files', description: 'the files', type: z.array(z.string()) }
+					],
+					run() {}
+				})
+			)
+			expect(reporter.getLogMessage()).toEqual(`
+Usage: cli cmd <arguments>
+
+Arguments:
+  <src=string>           the source
+  [host=string]          the host
+  <files=string...>      the files
+`)
+		})
 	})
 	describe('options', () => {
 		test('default (optional boolean)', () => {

--- a/packages/clibuilder/ts/ui.ts
+++ b/packages/clibuilder/ts/ui.ts
@@ -157,7 +157,7 @@ function generateArgumentsSection(command: createUI.Command) {
 	const entries: string[][] = []
 	let maxWidth = 0
 	command.arguments.forEach((a) => {
-		const argStr = !a.type?.isOptional ? `<${a.name}>` : `[${a.name}]`
+		const argStr = formatSignature(a.name, a.type, { defaultRequired: true, booleanIsFlag: false })
 		maxWidth = Math.max(maxWidth, argStr.length)
 		entries.push([argStr, a.description || ''])
 	})
@@ -197,28 +197,38 @@ function formatKeyValue(key: string, value: cli.Command.Options.Entry) {
 		.sort((a, b) => a.length - b.length)
 		.map((v) => (v.length === 1 ? `-${v}` : `--${v}`))
 		.join('|')
-	return formatOptionSignature(value.type, keyString)
+	return formatSignature(keyString, value.type, { defaultRequired: false, booleanIsFlag: true })
 }
 
-function formatOptionSignature(zodType: z.ZodTypeAny | undefined, keys: string) {
-	if (!zodType) return `[${keys}]`
-	const optional = isZodOptional(zodType)
-	const t = optional ? zodType._def.innerType : zodType
+/**
+ * Renders a name as it appears in the help output:
+ * `<name>` when required, `[name]` when optional,
+ * with a `=<type>` hint and a `...` variadic marker when the type is known.
+ *
+ * @param defaultRequired how a missing type is treated.
+ * Arguments are required by default while options are optional by default.
+ * @param booleanIsFlag options are flags so a `=boolean` hint is noise,
+ * while a boolean argument is a value the user has to type out.
+ */
+function formatSignature(
+	name: string,
+	zodType: z.ZodTypeAny | undefined,
+	{ defaultRequired, booleanIsFlag }: { defaultRequired: boolean; booleanIsFlag: boolean }
+) {
+	const required = zodType ? !isZodOptional(zodType) : defaultRequired
+	const body = `${name}${formatTypeHint(zodType, booleanIsFlag)}`
+	return required ? `<${body}>` : `[${body}]`
+}
+
+function formatTypeHint(zodType: z.ZodTypeAny | undefined, booleanIsFlag: boolean) {
+	if (!zodType) return ''
+	const t = isZodOptional(zodType) ? zodType._def.innerType : zodType
 	const isArray = isZodArray(t)
 	const at = isArray ? t.element : t
-	const valueType = isZodString(at)
-		? isArray
-			? '=string...'
-			: '=string'
-		: isZodNumber(at)
-			? isArray
-				? '=number...'
-				: '=number'
-			: isArray
-				? '=boolean...'
-				: ''
-
-	return optional ? `[${keys}${valueType}]` : `<${keys}${valueType}>`
+	const typeName = isZodString(at) ? 'string' : isZodNumber(at) ? 'number' : isZodBoolean(at) ? 'boolean' : ''
+	if (isArray) return typeName ? `=${typeName}...` : '...'
+	if (!typeName || (booleanIsFlag && typeName === 'boolean')) return ''
+	return `=${typeName}`
 }
 
 function formatDescription(value: cli.Command.Options.Entry) {


### PR DESCRIPTION
Closes #338

## The defect

`generateArgumentsSection` tested `!a.type?.isOptional` — the *method*, not its result. A function is always truthy, so the branch was inverted for every typed argument and the notation carried no type or variadic information:

```
Arguments:
  [req]                  required          <- required, rendered optional
  <bare>                 no type
  [host]                 optional
  [many]                 variadic          <- variadic, unmarked
```

## The fix

Arguments now go through the same signature formatter as options, extracted as `formatSignature`:

```
Arguments:
  <req=string>           required
  <bare>                 no type
  [host=string]          optional
  <many=string...>       variadic
  [optmany=string...]    optional variadic
```

Two things differ between the two call sites, so they are explicit parameters rather than duplicated logic:

- `defaultRequired` — an argument with no declared type is required, an option with no declared type is an optional flag. That already matched the `Usage:` line's defaults; now the sections agree with it.
- `booleanIsFlag` — `=boolean` is noise on an option (`[--flag]` is the whole story) but not on a positional argument, where the user has to type a value out.

## On `=string` type hints

The issue asks for `[host]=string..`. I kept the type hint and the variadic marker but put them inside the brackets — `[host=string...]` — because the options section has rendered `<--abc=string...>` for several releases, and having the two sections of one help message use two different notations is worse than either notation alone. Same reason for `...` over `..`.

## Docs

`apps/website/src/content/docs/api/ui.md` carried a sample whose argument line was produced by the bug (`[values]` for a required `z.array(z.number())`); it is corrected, and the notation is now documented as a table there.

## Tests

`ui.spec.ts` asserts the full rendered help string for required, optional, variadic, optional-variadic, boolean, and untyped arguments, plus one case with all three together, so the notation cannot drift silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)