### PR TITLE
fix: coerce argument and untyped-option values to their declared types

### DIFF
--- a/.changeset/hip-jars-attack.md
+++ b/.changeset/hip-jars-attack.md
@@ -1,0 +1,25 @@
+---
+'clibuilder': minor
+---
+
+Coerce argument and untyped-option values to match their declared types.
+
+Both fixes close a gap where the type system and the runtime disagreed about what `run(args)`
+receives.
+
+- Positional arguments are now coerced through the same conversion path options already use.
+  `type: z.number()` yields a `number`, `type: z.array(z.number())` yields `number[]`, and a value
+  that fails its schema is a usage error instead of being silently dropped. An array argument is
+  variadic: it consumes the remaining positionals. Previously every argument arrived as a raw string,
+  and `z.array(z.number())` ended up `undefined`.
+- An option declared without a `type` now defaults to `z.optional(z.boolean())` instead of
+  `z.optional(z.string())`, so a flag yields a real `true` rather than the string `'true'`.
+  `RunArgs` has always inferred this case as `boolean | undefined`.
+
+Note two behavior changes for code that relied on the old runtime values:
+
+- `--flag=somevalue` on an option with no declared `type` is now a usage error. Declare
+  `type: z.string()` to keep accepting a string value.
+- An argument declared with a type that has no string conversion (`z.enum`, `z.literal`) now has the
+  raw argv string handed to its schema, which accepts or rejects it. It is no longer passed through
+  unvalidated.

--- a/apps/website/src/content/docs/api/command.md
+++ b/apps/website/src/content/docs/api/command.md
@@ -55,7 +55,8 @@ type Argument = {
 ```
 
 Positional, matched in declaration order. `type` defaults to string. An array type makes the argument
-variadic; `z.optional()` makes it optional. Note that argument values are not coerced — see
+variadic, consuming the remaining positionals; `z.optional()` makes it optional. Argument values are
+coerced to the declared type — see
 [Arguments & Options](/clibuilder/guides/arguments-and-options/#arguments).
 
 ```ts
@@ -76,7 +77,7 @@ type Options = Record<string, {
 }>
 ```
 
-`type` defaults to a flag (`boolean | undefined`). Option values *are* coerced to the declared type,
+`type` defaults to a flag (`boolean | undefined`). Option values are coerced to the declared type,
 and a value that fails is a usage error.
 
 ```ts

--- a/apps/website/src/content/docs/api/zod.md
+++ b/apps/website/src/content/docs/api/zod.md
@@ -16,7 +16,7 @@ recognized" bugs.
 
 | Position | What the schema does |
 | --- | --- |
-| An [argument's](/clibuilder/api/command/#arguments) `type` | Marks it optional (`z.optional`) or variadic (`z.array`), and types `args.<name>` |
+| An [argument's](/clibuilder/api/command/#arguments) `type` | Coerces and validates the value, marks it optional (`z.optional`) or variadic (`z.array`), and types `args.<name>` |
 | An [option's](/clibuilder/api/command/#options) `type` | Coerces and validates the value, and types `args.<name>` |
 | A [command's](/clibuilder/guides/configuration/) `config` | Validates the loaded config file, and types `this.config` |
 
@@ -30,8 +30,9 @@ For arguments and options, the parser converts raw argv strings using these:
 - `z.array(z.string())`, `z.array(z.number())`, `z.array(z.boolean())`
 - `z.optional(...)` around any of the above
 
-Richer zod types — refinements, unions, transforms — are not converted from strings and will not
-behave as you expect on an argument or option. Do that validation inside `run()` instead.
+Richer zod types — refinements, unions, transforms — get no string conversion. The raw argv string is
+handed to the schema as-is, so ones that accept a string (`z.enum`, `z.literal('on')`) validate
+correctly, while ones expecting a converted value do not. Do that validation inside `run()` instead.
 
 Config schemas have no such restriction: the config file is already structured data, so any zod
 schema works.

--- a/apps/website/src/content/docs/guides/arguments-and-options.md
+++ b/apps/website/src/content/docs/guides/arguments-and-options.md
@@ -45,20 +45,11 @@ cli({ name: 'app', version: '1.0.0' }).command({
 $ app cat a.txt b.txt c.txt
 ```
 
-:::caution[Arguments arrive as strings]
-Positional argument values are **not** coerced to the declared type — only `z.optional()` (is it
-required?) and `z.array()` (is it variadic?) change behavior. Declaring
-`type: z.number()` on an argument makes `args.n` *typed* as `number`, but at runtime you get the raw
-string `'42'`.
+:::note
+Argument values are coerced to the declared type, just like options. `type: z.number()` gives you a
+real `number` in `run()`, and a value that doesn't fit its schema is a usage error.
 
-Use an **option** when you want a coerced non-string value, or convert the argument yourself:
-
-```ts
-arguments: [{ name: 'count', description: 'how many' }],
-run(args) {
-  const count = Number(args.count)
-}
-```
+An `z.array()` argument is variadic: it consumes the remaining positional arguments.
 :::
 
 ## Options
@@ -79,14 +70,12 @@ cli({ name: 'app', version: '1.0.0' }).default({
 ```
 
 :::note
-A flag declared without a `type` is *typed* as `boolean | undefined`, but the value handed to `run()`
-is the string `'true'` when the flag is present and `undefined` when it is not. Truthiness checks
-(`if (args.flag)`) behave as expected; strict comparisons (`args.flag === true`) do not. Declare
-`type: z.boolean()` when you need a real boolean.
+A flag declared without a `type` behaves exactly as `type: z.boolean()` would: `args.flag` is `true`
+when the flag is present and `undefined` when it is not. Passing a non-boolean value to it
+(`--flag=somevalue`) is a usage error — declare `type: z.string()` if you want to accept one.
 :::
 
-Unlike arguments, option values **are** coerced to the declared type, and a value that doesn't fit is
-a usage error.
+Option values are coerced to the declared type, and a value that doesn't fit is a usage error.
 
 ```ts
 options: {
@@ -174,10 +163,10 @@ cli({ name: 'app', version: '1.0.0' }).default({
 | --- | --- | --- | --- |
 | *(omitted)* | `string` / `boolean \| undefined` | The default — a string | The default — a flag |
 | `z.string()` | `string` | ✓ | ✓ |
-| `z.number()` | `number` | typed only, value stays a string | ✓ coerced |
-| `z.boolean()` | `boolean` | typed only, value stays a string | ✓ `--flag`, `--flag=true`, `--flag false` |
+| `z.number()` | `number` | ✓ coerced | ✓ coerced |
+| `z.boolean()` | `boolean` | ✓ coerced | ✓ `--flag`, `--flag=true`, `--flag false` |
 | `z.array(z.string())` | `string[]` | ✓ variadic | ✓ repeatable |
-| `z.array(z.number())` | `number[]` | not coerced — use an option | ✓ repeatable, coerced |
+| `z.array(z.number())` | `number[]` | ✓ variadic, coerced | ✓ repeatable, coerced |
 | `z.optional(...)` | `T \| undefined` | ✓ makes it optional | ✓ |
 
 Option validation happens before `run()` is called. A value that fails its schema, an unknown flag,

--- a/packages/clibuilder/ts/builder.spec.ts
+++ b/packages/clibuilder/ts/builder.spec.ts
@@ -41,6 +41,43 @@ describe('default()', () => {
 			.parse(argv('test-cli abc def'))
 		expect(a).toEqual(['abc', 'def'])
 	})
+	it('coerces arguments to their declared type', async () => {
+		const [builder] = setupBuilderTest()
+		const a = await builder
+			.default({
+				arguments: [{ name: 'a', description: 'd', type: z.number() }],
+				run(args) {
+					return args.a
+				}
+			})
+			.parse(argv('test-cli 42'))
+		expect(a).toBe(42)
+	})
+	it('runs the documented `sum` example', async () => {
+		const [builder] = setupBuilderTest()
+		const a = await builder
+			.command({
+				name: 'sum',
+				arguments: [{ name: 'values', description: 'values to add', type: z.array(z.number()) }],
+				run(args) {
+					return args.values.reduce((p, v) => p + v, 0)
+				}
+			})
+			.parse(argv('test-cli sum 1 2 3'))
+		expect(a).toBe(6)
+	})
+	it('an option without a declared type is a boolean', async () => {
+		const [builder] = setupBuilderTest()
+		const a = await builder
+			.default({
+				options: { f: { description: 'f' } },
+				run(args) {
+					return args.f
+				}
+			})
+			.parse(argv('test-cli --f'))
+		expect(a).toBe(true)
+	})
 
 	it('uses the app name in the ui', async () => {
 		const [builder, ctx] = setupBuilderTest(undefined, { name: 'some-cli' })

--- a/packages/clibuilder/ts/lookup_command.spec.ts
+++ b/packages/clibuilder/ts/lookup_command.spec.ts
@@ -62,6 +62,137 @@ describe('argument', () => {
 		expect(args).toEqual({ _: [] })
 		expect(errors).toEqual([{ type: 'missing-argument', name: 'arg' }])
 	})
+	test('argument without a type is a string', () => {
+		const defaultCommand = command({
+			name: '',
+			arguments: [{ name: 'arg', description: 'some arg' }],
+			run() {}
+		})
+		const { args, errors } = testLookupCommand(defaultCommand, 'my-cli 123')!
+		expect(args).toEqual({ _: [], arg: '123' })
+		expect(errors).toEqual([])
+	})
+	test('number argument is coerced to a number', () => {
+		const defaultCommand = command({
+			name: '',
+			arguments: [{ name: 'arg', type: z.number(), description: 'some arg' }],
+			run() {}
+		})
+		const { args, errors } = testLookupCommand(defaultCommand, 'my-cli 42')!
+		expect(args).toEqual({ _: [], arg: 42 })
+		expect(errors).toEqual([])
+	})
+	test('boolean argument is coerced to a boolean', () => {
+		const defaultCommand = command({
+			name: '',
+			arguments: [{ name: 'arg', type: z.boolean(), description: 'some arg' }],
+			run() {}
+		})
+		const { args, errors } = testLookupCommand(defaultCommand, 'my-cli false')!
+		expect(args).toEqual({ _: [], arg: false })
+		expect(errors).toEqual([])
+	})
+	test('a number argument that is not a number reports invalid-value', () => {
+		const defaultCommand = command({
+			name: '',
+			arguments: [{ name: 'arg', type: z.number(), description: 'some arg' }],
+			run() {}
+		})
+		const { args, errors } = testLookupCommand(defaultCommand, 'my-cli xyz')!
+		expect(args).toEqual({ _: [], arg: undefined })
+		a.satisfies(errors, [{ type: 'invalid-value', key: 'arg', value: 'xyz' }])
+	})
+	test('number array argument is variadic and coerced', () => {
+		const defaultCommand = command({
+			name: '',
+			arguments: [{ name: 'values', type: z.array(z.number()), description: 'some args' }],
+			run() {}
+		})
+		const { args, errors } = testLookupCommand(defaultCommand, 'my-cli 1 2 3')!
+		expect(args).toEqual({ _: [], values: [1, 2, 3] })
+		expect(errors).toEqual([])
+	})
+	test('string array argument is variadic', () => {
+		const defaultCommand = command({
+			name: '',
+			arguments: [{ name: 'values', type: z.array(z.string()), description: 'some args' }],
+			run() {}
+		})
+		const { args, errors } = testLookupCommand(defaultCommand, 'my-cli abc def')!
+		expect(args).toEqual({ _: [], values: ['abc', 'def'] })
+		expect(errors).toEqual([])
+	})
+	test('boolean array argument is variadic and coerced', () => {
+		const defaultCommand = command({
+			name: '',
+			arguments: [{ name: 'values', type: z.array(z.boolean()), description: 'some args' }],
+			run() {}
+		})
+		const { args, errors } = testLookupCommand(defaultCommand, 'my-cli true false')!
+		expect(args).toEqual({ _: [], values: [true, false] })
+		expect(errors).toEqual([])
+	})
+	test('optional array argument is coerced', () => {
+		const defaultCommand = command({
+			name: '',
+			arguments: [{ name: 'values', type: z.optional(z.array(z.number())), description: 'some args' }],
+			run() {}
+		})
+		const { args, errors } = testLookupCommand(defaultCommand, 'my-cli 1 2')!
+		expect(args).toEqual({ _: [], values: [1, 2] })
+		expect(errors).toEqual([])
+	})
+	test('an argument type without a string conversion is validated by the schema itself', () => {
+		const defaultCommand = command({
+			name: '',
+			arguments: [{ name: 'arg', type: z.enum(['abc', 'def']), description: 'some arg' }],
+			run() {}
+		})
+		expect(testLookupCommand(defaultCommand, 'my-cli abc')!.args).toEqual({ _: [], arg: 'abc' })
+		expect(testLookupCommand(defaultCommand, 'my-cli xyz')!.args).toEqual({ _: [], arg: undefined })
+	})
+})
+describe('option without a declared type', () => {
+	test('is a boolean when present', () => {
+		const defaultCommand = command({
+			name: '',
+			options: { f: { description: 'f' } },
+			run() {}
+		})
+		const { args, errors } = testLookupCommand(defaultCommand, 'my-cli --f')!
+		expect(args).toEqual({ _: [], f: true })
+		expect(errors).toEqual([])
+	})
+	test('bundled short flags are booleans', () => {
+		const defaultCommand = command({
+			name: '',
+			options: { a: { description: 'a' }, b: { description: 'b' } },
+			run() {}
+		})
+		const { args, errors } = testLookupCommand(defaultCommand, 'my-cli -ab')!
+		expect(args).toEqual({ _: [], a: true, b: true })
+		expect(errors).toEqual([])
+	})
+	test('accepts an explicit false', () => {
+		const defaultCommand = command({
+			name: '',
+			options: { f: { description: 'f' } },
+			run() {}
+		})
+		const { args, errors } = testLookupCommand(defaultCommand, 'my-cli --f=false')!
+		expect(args).toEqual({ _: [], f: false })
+		expect(errors).toEqual([])
+	})
+	test('a non-boolean value reports invalid-value', () => {
+		const defaultCommand = command({
+			name: '',
+			options: { f: { description: 'f' } },
+			run() {}
+		})
+		const { args, errors } = testLookupCommand(defaultCommand, 'my-cli --f=somevalue')!
+		expect(args).toEqual({ _: [], f: undefined })
+		a.satisfies(errors, [{ type: 'invalid-value', key: 'f', value: 'somevalue' }])
+	})
 })
 describe('options basic', () => {
 	test('---option is invalid', () => {

--- a/packages/clibuilder/ts/lookup_command.ts
+++ b/packages/clibuilder/ts/lookup_command.ts
@@ -79,22 +79,17 @@ function fillArguments(state: State) {
 	const argSpecs = command.arguments || []
 	state.args = argSpecs.reduce(
 		(p, s) => {
+			// an argument without a declared type is a string, matching `cli.Command.RunArgs`
+			const type = s.type ?? z.string()
 			if (args.length === 0) {
-				if (!isZodOptional(s.type)) state.errors.push({ type: 'missing-argument', name: s.name })
+				if (!isZodOptional(type)) state.errors.push({ type: 'missing-argument', name: s.name })
 				return p
 			}
-			if (isZodArray(s.type)) {
-				const e = s.type.element
-				let r = e.safeParse(args.shift())
-				p.args[s.name] = p.args[s.name] || []
-				while (r.success) {
-					p.args[s.name].push(r.data)
-					const arg = args.shift()
-					r = e.safeParse(arg)
-				}
-			} else {
-				p.args[s.name] = args.shift()!
-			}
+			// an array argument is variadic: it consumes the remaining positionals
+			const values = isZodArray(unwrapOptional(type)) ? args.splice(0) : [args.shift()!]
+			const [value, errors] = convertValue(type, s.name, values)
+			state.errors.push(...errors)
+			p.args[s.name] = value
 			return p
 		},
 		{ args: { _: [] } as { _: string[] } & Record<any, any> }
@@ -119,7 +114,8 @@ function fillInputOptions(state: State) {
 				s.errors.push({ type: 'invalid-key', key })
 				return s
 			}
-			const [value, errors] = convertValue(optionEntry!.type || z.optional(z.string()), key, state.rawArgs[key])
+			// an option without a declared type is a boolean, matching `cli.Command.RunArgs`
+			const [value, errors] = convertValue(optionEntry!.type || z.optional(z.boolean()), key, state.rawArgs[key])
 			if (errors) s.errors.push(...errors)
 			s.args[name] = value
 
@@ -159,7 +155,11 @@ function lookupOptions(command: cli.Command, key: string): [string, cli.Command.
 	return optKey ? [optKey, opts[optKey]] : []
 }
 
-function convertValue(t: z.ZodType<any>, key: string, values: string[]) {
+function unwrapOptional(t: z.ZodType<any>): z.ZodType<any> {
+	return isZodOptional(t) ? t._def.innerType : t
+}
+
+function convertValue(t: z.ZodType<any>, key: string, values: string[]): [any, lookupCommand.Error[]] {
 	const [r, errors] = parse(t, key, values)
 	return [r.success ? r.data : undefined, errors]
 }
@@ -216,9 +216,10 @@ function toParsable(
 			return [values, errors]
 		}
 	}
-	// not supported zod type
-	// istanbul ignore next
-	return [undefined, errors]
+	// zod type without a dedicated string conversion (e.g. `z.enum`).
+	// hand the raw value to `safeParse` and let the schema itself accept or reject it.
+	if (values.length > 1) errors.push({ type: 'expect-single', key, keyType: t, value: values })
+	return [values[values.length - 1], errors]
 }
 
 function toBoolean(


### PR DESCRIPTION
Closes #567
Closes #568

Both issues are the same defect class — the declared zod type says one thing, the value handed to `run(args)` is another — and both live in `ts/lookup_command.ts`, so they are fixed together.

## What changed

**#567 — arguments are now coerced.** `fillArguments` assigned `args.shift()` straight through, so a `z.number()` argument arrived as the string `'42'`. For array arguments it called `safeParse` against raw argv strings, so `z.array(z.number())` failed on the first element and the argument ended up `undefined`.

Arguments now go through the same `convertValue` → `parse` → `toParsable` path options already use — **one conversion path**, per the suggested fix in #567. An argument with no declared `type` defaults to `z.string()`, matching what `RunArgs` infers.

An array argument is now **variadic**: it consumes the remaining positionals. The old "consume while the element parses" loop could not survive the switch to real coercion, and consuming the remainder is both the standard variadic semantics and what makes the documented `sum` example work.

**#568 — an untyped option is now a real boolean.** `fillInputOptions` fell back to `z.optional(z.string())` while `RunArgs` in `ts/cli.ts` inferred `boolean | undefined`. It now falls back to `z.optional(z.boolean())`, so the runtime matches the published type. No type-level change was needed — `cli.ts` was already correct, and `command.spec.ts` / `cli.spec.ts` already assert `boolean | undefined`.

**Supporting change.** `toParsable`'s "not supported zod type" branch returned `undefined`, dropping the value. Now that arguments route through it, that would have regressed argument types like `z.enum(['a','b'])`, which previously worked by passing the string through. It now hands the raw value to `safeParse` and lets the schema accept or reject it. This is unreachable for the option types that have conversions, so option behavior is unchanged.

## The `--flag=somevalue` judgment call

#568 flagged this as worth checking before defaulting to boolean. I searched the specs, `test-apps/`, and `test-plugins/`: every untyped option in the repo appears only in **type-level** tests (which already assert `boolean | undefined`) and in `ui.spec.ts` help rendering, which reads `options[key].type` directly and is unaffected. **Nothing relies on the string value**, so the straightforward fix is safe here.

It is still a behavior change for downstream users: `--flag=somevalue` on an untyped option now produces an `invalid-value` usage error rather than silently yielding a string. Declaring `type: z.string()` restores the old behavior. Called out in the changeset.

## Verification

- All 230 pre-existing tests pass **unchanged** — no existing assertion needed rewriting.
- 16 new tests: argument coercion (number, boolean, untyped, invalid-value, variadic number/string/boolean arrays, optional array, `z.enum` fallback), untyped-option booleans (`--f`, bundled `-ab`, `--f=false`, `--f=somevalue`), plus end-to-end `builder.spec.ts` coverage of the documented `sum` example. #567 noted the missing runtime test for `z.array(z.number())` arguments; that gap is now closed at both the unit and end-to-end level.
- `pnpm build`, `pnpm test` (246 passed), `pnpm lint` all green.

Acceptance conditions from the issues, verified end to end:

| | |
| --- | --- |
| `z.number()` argument | `number 42` |
| `app sum 1 2 3` | `6` |
| untyped flag, `args.f === true` | `true` |

## Docs

The `sum` example in `README.md` and `getting-started/introduction.md` is correct as written and needed no change — it just works now.

The docs site carried explicit caveats describing both bugs (added in #566). Those are now false, so `guides/arguments-and-options.md`, `api/command.md`, and `api/zod.md` are updated to describe the fixed behavior.

## Note on versioning

The changeset is `minor`. Both are bug fixes that align the runtime to types that were already published, so no correctly-typed code should break. If you would rather ship the `--flag=somevalue` change as a major, that is a one-line edit to `.changeset/hip-jars-attack.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)