### PR TITLE
docs: document plugin discovery and add a showcase page

### DIFF
--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -61,6 +61,10 @@ export default defineConfig({
 						{ label: 'enableCompileCache()', slug: 'api/compile-cache' },
 						{ label: 'z', slug: 'api/zod' }
 					]
+				},
+				{
+					label: 'Showcase',
+					slug: 'showcase'
 				}
 			]
 		})

--- a/apps/website/src/components/showcase-grid.astro
+++ b/apps/website/src/components/showcase-grid.astro
@@ -1,0 +1,68 @@
+---
+// biome-ignore lint/correctness/noUnusedImports: biome only parses an `.astro` file's frontmatter, so it cannot see the template's use below
+import { showcase } from '../data/showcase'
+---
+
+<ul class="cb-showcase not-content">
+	{
+		showcase.map((entry) => (
+			<li class="cb-showcase-card">
+				<h3>
+					<a href={entry.repo}>{entry.name}</a>
+				</h3>
+				<p>{entry.description}</p>
+				<p class="cb-showcase-links">
+					<a href={entry.repo}>repo</a>
+					{entry.npm && <a href={entry.npm}>npm</a>}
+				</p>
+			</li>
+		))
+	}
+</ul>
+
+<style>
+	.cb-showcase {
+		display: grid;
+		gap: 1rem;
+		grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
+		list-style: none;
+		margin-top: 1.5rem;
+		padding: 0;
+	}
+
+	.cb-showcase-card {
+		border: 1px solid var(--sl-color-hairline, var(--sl-color-gray-5));
+		border-radius: 0.5rem;
+		padding: 1rem 1.25rem;
+	}
+
+	.cb-showcase-card h3 {
+		font-size: var(--sl-text-lg);
+		margin: 0;
+	}
+
+	.cb-showcase-card h3 a {
+		color: var(--sl-color-white);
+		text-decoration: none;
+	}
+
+	.cb-showcase-card h3 a:hover {
+		color: var(--sl-color-accent-high);
+	}
+
+	.cb-showcase-card p {
+		color: var(--sl-color-gray-2);
+		font-size: var(--sl-text-sm);
+		margin: 0.5rem 0 0;
+	}
+
+	.cb-showcase-links {
+		display: flex;
+		gap: 1rem;
+	}
+
+	.cb-showcase-links a {
+		color: var(--sl-color-accent-high);
+		font-size: var(--sl-text-xs);
+	}
+</style>

--- a/apps/website/src/content/docs/guides/plugins.md
+++ b/apps/website/src/content/docs/guides/plugins.md
@@ -1,11 +1,17 @@
 ---
 title: Plugins
-description: Ship commands as separate packages and load them into a CLI through its config file.
+description: Ship commands as separate packages, load them into a CLI through its config file, and make them discoverable through keywords.
 ---
 
 A plugin is an ordinary npm package that exports an `activate()` function and adds commands through
 it. This is how a CLI can be built in a distributed fashion — the core stays small, and features ship
 as packages that plug into it.
+
+Two mechanisms are involved, and it helps to keep them apart:
+
+- **Loading** — which plugins actually run. Driven by the `plugins` array in the CLI's config file.
+- **Discovery** — which plugins *exist*, on disk or on npm, so a user can decide what to load. Driven
+  by the CLI's `keywords`.
 
 ## Enabling plugins in your CLI
 
@@ -23,7 +29,46 @@ cli({
   .parse(process.argv)
 ```
 
-If you declare `config` without `keywords`, the CLI name is used as the keyword.
+A CLI "accepts plugins" if it sets `config` **or** a non-empty `keywords`. That single condition is
+what turns on config-driven plugin loading and adds the built-in `plugins` command.
+
+### Choosing a keywords namespace
+
+A keyword is a public contract: it is the string a plugin author has to put in their
+`package.json` for your users to find their package. Pick one that is unlikely to collide with
+anything else on npm, and then treat it as stable — changing it later orphans every plugin already
+published against the old one.
+
+`<cli-name>-plugin` is the convention this library's own fixtures use, and it is a good default:
+
+```ts
+cli({ name: 'my-cli', version: '1.0.0', config: true, keywords: ['my-cli-plugin'] })
+```
+
+A few notes on the shape of the list:
+
+- **The CLI name alone is a weak keyword.** `keywords: ['my-cli']` matches anything on npm that
+  happens to carry your CLI's name — including packages that have nothing to do with your plugin
+  contract. The `-plugin` suffix narrows it to packages that opted in deliberately.
+- **`keywords` is an array**, and a package matches if it carries *any* of them. That is the escape
+  hatch for renaming: publish under the new keyword and keep the old one listed until the ecosystem
+  catches up.
+- **If you set `config` and omit `keywords`, the CLI `name` is used as the keyword.** This is a
+  convenience default, not a recommendation — a CLI that expects a real plugin ecosystem should
+  declare its namespace explicitly.
+
+```ts
+// keywords is ['my-cli'] — same as writing keywords: ['my-cli']
+cli({ name: 'my-cli', version: '1.0.0', config: true })
+```
+
+The default also applies when `config` names a different file — the keyword still comes from `name`,
+not from the config name:
+
+```ts
+// config file is `my-tool.json`, but the plugin keyword is still 'my-cli'
+cli({ name: 'my-cli', version: '1.0.0', config: 'my-tool' })
+```
 
 ## Listing plugins in config
 
@@ -41,6 +86,103 @@ Before v8, `clibuilder` scanned `node_modules` to discover plugins. Listing them
 dramatically faster to start, and works with package managers that don't lay out a flat
 `node_modules` — Yarn PnP and pnpm.
 :::
+
+The trade-off is that installing a plugin is not enough to activate it — the user also adds it to
+`plugins`. That is deliberate: a package that lands in `node_modules` as a transitive dependency
+should not be able to inject commands into a CLI the user runs.
+
+A plugin that fails to import, or that has no `activate` export, is skipped with a warning rather
+than crashing the CLI. Run with `--verbose` to see which plugin was skipped and why:
+
+```sh
+$ my-cli --verbose --help
+clibuilder loading plugin bad-plugin
+clibuilder not a valid plugin bad-plugin
+```
+
+## The built-in `plugins` command
+
+Any CLI that accepts plugins gets a `plugins` command added automatically. You do not register it,
+and it shows up in the help output alongside your own commands:
+
+```sh
+$ my-cli plugins -h
+
+Usage: my-cli plugins <command>
+
+  Commands related to the plugins of the cli
+
+Commands:
+  list (ls), search
+
+plugins <command> -h     Get help for <command>
+```
+
+The two sub-commands answer two different questions.
+
+### `plugins list` — what is installed
+
+`list` walks the packages installed in the current working directory and reports the ones carrying
+any of the CLI's keywords. It reads the local dependency tree only; it never touches the network.
+
+```sh
+$ my-cli plugins list
+found the following plugins:
+
+  my-cli-plugin
+  my-cli-plugin-git
+  @acme/my-cli-plugin-deploy
+```
+
+With exactly one match, and with none:
+
+```sh
+$ my-cli plugins list
+found one plugin: my-cli-plugin
+```
+
+```sh
+$ my-cli plugins list
+no plugin with keywords: my-cli-plugin
+```
+
+Note what `list` is *not*: it reports what is installed, not what is loaded. A package can appear
+here and still be inert because it is missing from the config's `plugins` array.
+
+### `plugins search` — what exists on npm
+
+`search` queries the npm registry for published packages carrying the CLI's keywords. This is how a
+user finds a plugin they have not installed yet.
+
+```sh
+$ my-cli plugins search
+found the following packages:
+
+  my-cli-plugin
+  my-cli-plugin-git
+  @acme/my-cli-plugin-deploy
+```
+
+The zero- and one-result forms mirror `list`, worded for packages rather than plugins:
+
+```sh
+$ my-cli plugins search
+no package with keywords: my-cli-plugin
+```
+
+```sh
+$ my-cli plugins search
+found one package: my-cli-plugin
+```
+
+Neither sub-command installs anything or edits your config. Adopting a plugin stays a deliberate,
+two-step act:
+
+```sh
+$ my-cli plugins search        # find it
+$ npm install my-cli-plugin    # install it
+                               # then add it to `plugins` in the config file
+```
 
 ## Writing a plugin
 
@@ -74,37 +216,53 @@ export function activate({ addCommand }: PluginActivationContext) {
 }
 ```
 
-Then add the host CLI's keyword to your `package.json` so the package is discoverable:
+`addCommand` may be called more than once to contribute several top-level commands. The commands it
+receives are ordinary [commands](/clibuilder/guides/commands/) — arguments, options, sub-commands,
+and config schemas all work exactly as they do in the host CLI.
+
+`activate` is called during `parse()`, before the CLI resolves which command to run. Keep it cheap:
+build command objects and return. Anything expensive belongs inside `run()`, so a user typing
+`my-cli --help` does not pay for work no command asked for.
+
+### Publishing so `plugins search` finds you
+
+The host CLI's keyword goes in your `package.json` `keywords`. Without it, your package is invisible
+to both `plugins list` and `plugins search`, no matter how correct the rest of the plugin is.
 
 ```json
 {
-  "name": "my-cli-plugin",
-  "keywords": ["my-cli-plugin", "vocaloid"],
+  "name": "my-cli-plugin-git",
+  "description": "git commands for my-cli",
+  "keywords": ["my-cli-plugin", "git"],
   "main": "./cjs/index.js",
   "exports": { "import": "./esm/index.js", "require": "./cjs/index.js" }
 }
 ```
 
-`addCommand` may be called more than once to contribute several top-level commands.
+Check the host CLI's docs for the exact keyword. If it is not documented, the CLI's own
+`keywords` — or, failing that, its `name` — is the value to use.
 
-A plugin that fails to import, or that has no `activate` export, is skipped with a warning rather
-than crashing the CLI — run with `--verbose` to see which plugin was skipped and why.
+Extra keywords are free, and worth adding: they describe *what* the plugin does, while the host
+keyword describes *which CLI it plugs into*. Both matter to someone reading a `plugins search`
+result list.
 
-## The built-in `plugins` command
+### Naming conventions
 
-A CLI that accepts config (or declares keywords) automatically gets a `plugins` command:
+`plugins search` returns bare package names, with no descriptions. The name is the entire signal a
+user gets, so let it carry the CLI it targets:
 
-```sh
-# Installed packages carrying the CLI's keywords
-$ my-cli plugins list
-$ my-cli plugins ls
+| Pattern | Example | Reads as |
+| --- | --- | --- |
+| `<cli>-plugin-<feature>` | `my-cli-plugin-git` | the git plugin for `my-cli` |
+| `@scope/<cli>-plugin-<feature>` | `@acme/my-cli-plugin-deploy` | Acme's deploy plugin for `my-cli` |
+| `<cli>-plugin` | `my-cli-plugin` | the one canonical plugin for `my-cli` |
 
-# Packages on npm carrying the CLI's keywords
-$ my-cli plugins search
-```
+Two things worth avoiding: a name that says nothing about the host CLI (`git-helper` in a
+`my-cli plugins search` list is a guessing game), and a name that implies official status you do not
+have. Publish under a scope if you want your own namespace.
 
-`list` looks at what is installed; `search` looks at the registry. Neither installs anything or edits
-your config — adding a plugin to `plugins` is a deliberate act.
+Whatever you pick, keep the command names your plugin adds distinct from the host's. Commands are
+merged into one namespace, and a collision is resolved by load order, not by anything a user can see.
 
 ## Testing a plugin
 
@@ -123,3 +281,6 @@ test('miku sings', async () => {
   expect(messages).toBe('🎵')
 })
 ```
+
+Calling `activate` yourself with a stub `addCommand` also checks the half of the contract that only
+the host normally exercises — that `activate` is exported, and that it registers what you expect.

--- a/apps/website/src/content/docs/index.mdx
+++ b/apps/website/src/content/docs/index.mdx
@@ -12,6 +12,10 @@ hero:
       link: /clibuilder/api/
       icon: open-book
       variant: minimal
+    - text: Showcase
+      link: /clibuilder/showcase/
+      icon: rocket
+      variant: minimal
 ---
 
 import { CardGrid, LinkCard } from '@astrojs/starlight/components'

--- a/apps/website/src/content/docs/showcase.mdx
+++ b/apps/website/src/content/docs/showcase.mdx
@@ -1,0 +1,30 @@
+---
+title: Showcase
+description: Command line applications built with clibuilder.
+---
+
+import ShowcaseGrid from '../../components/showcase-grid.astro'
+
+Command line applications built with `clibuilder`. Every entry here was checked against its source —
+if it is on this page, `clibuilder` is in its `package.json`.
+
+<ShowcaseGrid />
+
+## Add your CLI
+
+The list is a plain data file,
+[`src/data/showcase.ts`](https://github.com/clibuilder/clibuilder/blob/main/apps/website/src/data/showcase.ts).
+There is no submission form and no approval queue — additions come in as pull requests against that
+file:
+
+```ts
+{
+  name: 'your-cli',
+  description: 'One line on what it does.',
+  repo: 'https://github.com/you/your-cli',
+  npm: 'https://www.npmjs.com/package/your-cli' // optional
+}
+```
+
+Two things a reviewer will check: that the project actually depends on `clibuilder`, and that `repo`
+resolves. `npm` is optional — plenty of useful CLIs are never published.

--- a/apps/website/src/data/showcase.ts
+++ b/apps/website/src/data/showcase.ts
@@ -1,0 +1,54 @@
+/**
+ * Curated list of CLIs built with `clibuilder`.
+ *
+ * This is static, hand-maintained data — there is no submission form and no registry sync.
+ * To add an entry, open a pull request against this file.
+ *
+ * Two rules keep the list useful:
+ *
+ * 1. The project must actually depend on `clibuilder` — a reviewer should be able to open the
+ *    linked repository and find it in a `package.json`.
+ * 2. `repo` must resolve. `npm` is optional; omit it for projects that are not published.
+ */
+export type ShowcaseEntry = {
+	/** Display name — the npm package name where there is one, otherwise the project name. */
+	name: string
+	/** One line on what the CLI does. No marketing copy. */
+	description: string
+	/** Source repository. Required. */
+	repo: string
+	/** npm package page, for published CLIs. */
+	npm?: string
+}
+
+export const showcase: ShowcaseEntry[] = [
+	{
+		name: 'repobuddy',
+		description:
+			'Manages repository configuration — GitHub setup, dependency update PRs — and installs agent skills for AI coding assistants.',
+		repo: 'https://github.com/repobuddy/repobuddy',
+		npm: 'https://www.npmjs.com/package/repobuddy'
+	},
+	{
+		name: '@mocktomata/cli',
+		description: 'Command line interface for mocktomata, a behavior simulator for tests.',
+		repo: 'https://github.com/mocktomata/mocktomata',
+		npm: 'https://www.npmjs.com/package/@mocktomata/cli'
+	},
+	{
+		name: '@unional/uni-cli',
+		description: 'Development CLI tool for day-to-day repository chores.',
+		repo: 'https://github.com/unional/uni-cli',
+		npm: 'https://www.npmjs.com/package/@unional/uni-cli'
+	},
+	{
+		name: 'eslintest',
+		description: 'Test runner for eslint configs, rules, and plugins.',
+		repo: 'https://github.com/unional/eslintest'
+	},
+	{
+		name: 'upstream-monitor',
+		description: 'Watches upstream dependencies of a project and reports what has moved.',
+		repo: 'https://github.com/jplomas/upstream-monitor'
+	}
+]


### PR DESCRIPTION
Closes #564
Closes #563

Both issues add pages to `apps/website` and both touch the Starlight sidebar in `apps/website/astro.config.mjs`, so they ship together to avoid colliding there. Nothing under `packages/` is touched, so no changeset is needed.

## #564 — plugin discoverability

Extends the existing `guides/plugins` page rather than adding a competing one. New material:

- **Loading vs. discovery** framed up front as two separate mechanisms — `plugins` in the config file decides what runs, `keywords` decides what is findable.
- **Choosing a `keywords` namespace** — why `<cli-name>-plugin` beats the bare CLI name, that the list is an any-match array (and therefore the escape hatch for renaming), and that `keywords` defaults to the CLI `name` when `config` is set — including that the default still comes from `name` when `config` is a *string* naming a different file.
- **The built-in `plugins` command** — that it is added automatically to any CLI setting `config` or non-empty `keywords`, with its help output and the zero / one / many output of both `list` and `search`, and what distinguishes them (`list` reads the local dependency tree, `search` queries the npm registry; neither installs anything or edits config).
- **For plugin authors** — which keyword to publish with, keeping `activate` cheap because it runs during `parse()` before command resolution, and a naming-convention table, since `plugins search` returns bare package names with no descriptions.

Every output block was produced by running a real plugin-accepting CLI against this repo's `test-plugins/*` fixtures and, for `search`, against the live npm registry. Config-based loading, the keyword default, and the skipped-plugin warning were each exercised end to end rather than read off the source.

### One thing found while verifying

`plugins list` declares `alias: ['ls']`, and the generated help advertises `list (ls)` — but `my-cli plugins ls` does not run `list`. It falls through to the `plugins` help, because `matchCommand()` in `lookup_command.ts` matches on `command.name` only and never consults `command.alias`. This appears to affect command aliases generally, not just this one.

The page therefore documents `plugins list` and never instructs anyone to type `plugins ls`. The `list (ls)` string that appears in the quoted help block is verbatim real output, not a claim that it works. Filed separately as #573 — it is a fix under `packages/`, outside this PR's scope.

## #563 — showcase

- `src/data/showcase.ts` — hand-curated, typed entries (name, one-line description, repo, optional npm). No submission form, no moderation queue, no registry sync, per the issue's non-goals.
- `src/components/showcase-grid.astro` — renders the data as cards.
- `src/content/docs/showcase.mdx` — the page, plus an "Add your CLI" section pointing contributors at the data file.
- Sidebar entry, and a `Showcase` hero action on the homepage.

**On the seed list — it is short and honestly so.** npm exposes no dependents for `clibuilder` (`search?text=depended:clibuilder` returns zero), so the list was built from GitHub code search and each candidate's `package.json` verified to actually depend on `clibuilder`:

| Entry | Verified via | On npm |
| --- | --- | --- |
| `repobuddy` | `clibuilder: ^9.0.0` | yes |
| `@mocktomata/cli` | `clibuilder: ^8.0.10` | yes |
| `@unional/uni-cli` | `clibuilder: ^4.4.3` | yes |
| `eslintest` | `clibuilder: ^6.4.4` | no — repo only |
| `upstream-monitor` | `clibuilder: ^9.0.0` | no — repo only |

Four of the five sit in the maintainer's own orbit; `upstream-monitor` (jplomas) is the one independent adopter I could verify. Nothing is invented — anything not confirmable in a `package.json` was left off. The structure is the deliverable here; the list grows by PR.

## Verification

- `pnpm build` — green (turbo, all 3 tasks; 20 pages built)
- `pnpm lint` — green
- `pnpm --filter website typecheck` (`astro check`) — 0 errors, 0 warnings, 0 hints
- Sidebar entry and homepage hero action both resolve to `/clibuilder/showcase/` in the built output; all internal links in the plugins guide point at existing pages
- No changeset — `apps/website` is private and unpublished

`showcase-grid.astro` carries a `biome-ignore` for `noUnusedImports`: biome parses only an `.astro` file's frontmatter, so it cannot see the template's use of the import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
