### PR TITLE
test: cover async plugin command process exit

### DIFF
--- a/packages/clibuilder/.depcheckrc.yaml
+++ b/packages/clibuilder/.depcheckrc.yaml
@@ -7,6 +7,7 @@ ignores:
   - standard-log-color
   - ts-jest
   - tslib
+  - async-plugin
   - bad-plugin
   - bad-plugin-no-index
   - cjs-plugin

--- a/packages/clibuilder/fixtures/cli-with-async-plugin/bin.js
+++ b/packages/clibuilder/fixtures/cli-with-async-plugin/bin.js
@@ -1,0 +1,9 @@
+const { cli } = require('clibuilder')
+
+const app = cli({
+	name: 'test-cli',
+	version: '1.0.0',
+	config: true
+})
+
+app.parse(process.argv)

--- a/packages/clibuilder/fixtures/cli-with-async-plugin/command.json
+++ b/packages/clibuilder/fixtures/cli-with-async-plugin/command.json
@@ -1,0 +1,4 @@
+{
+	"command": "node",
+	"args": ["bin.js", "async", "echo", "hello"]
+}

--- a/packages/clibuilder/fixtures/cli-with-async-plugin/package.json
+++ b/packages/clibuilder/fixtures/cli-with-async-plugin/package.json
@@ -1,0 +1,9 @@
+{
+	"name": "fixtures-cli-with-async-plugin",
+	"private": true,
+	"type": "commonjs",
+	"devDependencies": {
+		"async-plugin": "workspace:*",
+		"clibuilder": "workspace:*"
+	}
+}

--- a/packages/clibuilder/fixtures/cli-with-async-plugin/test-clirc.json
+++ b/packages/clibuilder/fixtures/cli-with-async-plugin/test-clirc.json
@@ -1,0 +1,3 @@
+{
+	"plugins": ["async-plugin"]
+}

--- a/packages/clibuilder/package.json
+++ b/packages/clibuilder/package.json
@@ -83,6 +83,7 @@
 		"@types/wordwrap": "github:types/wordwrap",
 		"@unional/fixture": "^3.2.16",
 		"assertron": "^11.2.1",
+		"async-plugin": "workspace:*",
 		"bad-plugin": "workspace:*",
 		"bad-plugin-no-index": "workspace:*",
 		"cjs-plugin": "workspace:*",

--- a/packages/clibuilder/ts/plugins.spec.ts
+++ b/packages/clibuilder/ts/plugins.spec.ts
@@ -29,3 +29,15 @@ it('loads one plugin', async () => {
 	})
 	expect(stdout).toEqual('echo hello')
 })
+
+// https://github.com/clibuilder/clibuilder/issues/286
+// `execCommand()` resolves only when the child process exits on its own,
+// so this hangs (and times out) if an async plugin command retains the event loop.
+it('exits after an async plugin command resolves', async () => {
+	const { stdout } = await execCommand({
+		caseType: 'folder',
+		caseName: 'fixtures/cli-with-async-plugin',
+		casePath: getFixturePath('cli-with-async-plugin')
+	})
+	expect(stdout).toEqual('echo hello')
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       assertron:
         specifier: ^11.2.1
         version: 11.5.2
+      async-plugin:
+        specifier: workspace:*
+        version: link:../../test-plugins/async-plugin
       bad-plugin:
         specifier: workspace:*
         version: link:../../test-plugins/bad-plugin
@@ -250,6 +253,15 @@ importers:
 
   packages/clibuilder/fixtures/cli-no-plugin:
     devDependencies:
+      clibuilder:
+        specifier: workspace:*
+        version: link:../..
+
+  packages/clibuilder/fixtures/cli-with-async-plugin:
+    devDependencies:
+      async-plugin:
+        specifier: workspace:*
+        version: link:../../../../test-plugins/async-plugin
       clibuilder:
         specifier: workspace:*
         version: link:../..
@@ -523,6 +535,8 @@ importers:
       typescript:
         specifier: ^5.0.4
         version: 5.9.3
+
+  test-plugins/async-plugin: {}
 
   test-plugins/bad-plugin: {}
 

--- a/test-plugins/async-plugin/index.js
+++ b/test-plugins/async-plugin/index.js
@@ -1,0 +1,18 @@
+export function activate(cli) {
+	cli.addCommand({
+		name: 'async',
+		commands: [
+			{
+				name: 'echo',
+				arguments: [{ name: 'arg1' }],
+				// awaits real async work before producing output.
+				// The process must still exit on its own once this settles.
+				async run(args) {
+					await new Promise((resolve) => setTimeout(resolve, 50))
+					this.ui.info('echo', args.arg1)
+					return args.arg1
+				}
+			}
+		]
+	})
+}

--- a/test-plugins/async-plugin/package.json
+++ b/test-plugins/async-plugin/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "async-plugin",
+	"version": "0.0.0",
+	"private": true,
+	"keywords": [
+		"test-cli"
+	],
+	"type": "module",
+	"main": "index.js"
+}


### PR DESCRIPTION
Triage of three stale pre-v8 issues: #286, #327, #405. Each carries a full reproduction and verdict as an issue comment. Only one produced code.

## #286 — plugin async command does not exit → **does not reproduce, closing**

Filed 2020 with an empty body. Reconstructed from the title and verified against every async shape a plugin command can take:

| shape | exit | non-stdio handles |
| --- | --- | --- |
| `await` a timer | 0 (103ms) | none |
| `await` fs io | 0 (54ms) | none |
| chained `await`s | 0 (55ms) | none |
| async throw | 0 (66ms), rejects `boom` | none |
| returns a promise (not `async`) | 0 (101ms) | none |
| `setInterval` + `clearInterval` | 0 (105ms) | none |
| **plugin leaks an uncleared `setInterval`** | **hangs, SIGTERM at 6s** | — |

`builder.parse()` returns the promise from `commandInstance.run()`, so the awaited value propagates and the library retains nothing. The only hang is a plugin leaking its own handle, which is the plugin author's bug.

**This PR adds the fixture that pins that.** `execCommand()` resolves only when the child process exits on its own, so a regression that retains the event loop times the test out instead of passing quietly.

## #327 — yarn v2 / PnP → **no code here; broad issue closes, narrow one filed**

Verified against a real Yarn 4.5.3 PnP install with no `node_modules` on disk. Loading and running plugins works. `plugins list` silently returns nothing, because `find-installed-packages` walks `node_modules` directories. Same app under npm finds the plugin. Details and a verified `pnpapi` fix path are on the issue.

## #405 — TS config → **no code; Council decision**

Confirmed unimplemented (`getConfigFilenames` has no `.ts` candidate). Native type-stripping is *not* free on the supported range — `engines.node` is `>= 18` and CI still covers Node 18, where `.ts` import fails outright. Recommendation on the issue; not implemented unilaterally, and the fix would land in `ts/config.ts`, which this branch does not own.

## Notes

- No changeset: test surface only, no production code changed — matching #557.
- `pnpm build`, `pnpm test` (231 passed), `pnpm lint` all green locally.

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)