### PR TITLE
feat(clibuilder): jsonc config, config lookup API, and --show-config

### DIFF
--- a/.changeset/quiet-donkeys-shake.md
+++ b/.changeset/quiet-donkeys-shake.md
@@ -1,0 +1,34 @@
+---
+'clibuilder': minor
+---
+
+Config subsystem: jsonc support, a public lookup/load API, and `--show-config`.
+
+**JSONC config (#341)**
+
+`.jsonc` and `.jsonc`-suffixed rc files are now searched for, and `.json` files may contain comments
+and trailing commas. Parsing goes through `jsonc-parser`, so comment-like sequences inside strings
+are left alone — `"http://example.com"` is no longer at risk of being truncated at the `//`.
+
+The format is now chosen by extension rather than by trying every parser in turn. Extension-less
+candidates such as `.apprc` still infer their format from content (JSONC, then YAML, then module).
+One consequence: a `.json` file that is not valid JSON now reports a parse error naming the file,
+where before it was silently retried as YAML and could load as something unintended.
+
+**Config lookup/load API (#488)**
+
+`clibuilder` now exports its config resolution, so plugins and tools can ask where a config came
+from, not just what it holds:
+
+- `lookupConfig({ cwd }, name)` — resolve the origin without reading the file
+- `resolveConfig({ cwd, ui }, name)` — the config plus its provenance
+- `loadConfig`, `readConfigFile`, `getConfigFilenames`, `getConfigFormat`, `describeConfigSource`
+
+A resolved `source` is `{ type: 'file', path, format }`, `{ type: 'package.json', path, property }`,
+or `{ type: 'none' }`. These are read-only; writing config back to disk is not supported yet.
+
+**`--show-config` (#317)**
+
+A cli declaring `config` now accepts `--show-config`, which prints the resolved config and where it
+was loaded from — the matching file path, the `package.json` property, or that nothing was found.
+Clis without config do not advertise the option.

--- a/apps/website/src/content/docs/guides/arguments-and-options.md
+++ b/apps/website/src/content/docs/guides/arguments-and-options.md
@@ -197,3 +197,10 @@ Every command inherits these; you don't declare them, and you shouldn't shadow t
 | `--debug-cli` | | Display level `trace`, including clibuilder's own internal messages |
 
 `args.help` is always present in the inferred type for that reason.
+
+One more is added only when the CLI declares `config`, since it would have nothing to report
+otherwise:
+
+| Flag | Alias | Effect |
+| --- | --- | --- |
+| `--show-config` | | Print the resolved config and the file it came from — see [Configuration](/clibuilder/guides/configuration/#inspecting-the-resolved-config) |

--- a/apps/website/src/content/docs/guides/configuration.md
+++ b/apps/website/src/content/docs/guides/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Let your CLI read a config file — JSON, YAML, cjs, or mjs — and validate it per command with zod.
+description: Let your CLI read a config file — JSON, JSONC, YAML, cjs, or mjs — and validate it per command with zod.
 ---
 
 A CLI opts into config by declaring `config` on [`cli()`](/clibuilder/api/cli/). Doing so also makes
@@ -22,8 +22,8 @@ cli({ name: 'app', version: '1.0.0', config: 'alt-config.json' })
 Given a config name of `app`, these filenames are searched, in order, walking up from the current
 working directory:
 
-- `app`, `app.cjs`, `app.mjs`, `app.js`, `app.json`, `app.yml`, `app.yaml`
-- `apprc.cjs`, `apprc.mjs`, `apprc.js`, `apprc.json`, `apprc.yml`, `apprc.yaml`, `apprc`
+- `app`, `app.cjs`, `app.mjs`, `app.js`, `app.json`, `app.jsonc`, `app.yml`, `app.yaml`
+- `apprc.cjs`, `apprc.mjs`, `apprc.js`, `apprc.json`, `apprc.jsonc`, `apprc.yml`, `apprc.yaml`, `apprc`
 
 Each also matches with a leading dot — `.apprc.json`, `.app.yaml`, and so on. (If your config name
 already starts with `.`, the dotted variants are skipped.)
@@ -100,10 +100,31 @@ Use `z.optional()` or `.default()` in the schema for fields you don't want to be
 
 | Extension | Format |
 | --- | --- |
-| `.json`, none | JSON |
+| `.json`, `.jsonc` | JSON with comments and trailing commas |
 | `.yml`, `.yaml` | YAML |
 | `.cjs` | CommonJS module — its export is the config |
 | `.mjs`, `.js` | ES module — its default export is the config |
+| none | inferred from the content — JSONC, then YAML, then module |
+
+The format comes from the extension, so a `.json` file that is not valid JSON is reported as a parse
+error against that file rather than being silently retried as YAML.
+
+### Comments and trailing commas
+
+`.json` and `.jsonc` are both parsed as [JSONC], so comments and trailing commas are allowed in
+either. Extension-less files such as `.apprc` get the same treatment when their content looks like
+JSON.
+
+```jsonc
+{
+  // the preset to build with
+  "presets": "recommended",
+  "plugins": ["my-cli-plugin"],
+}
+```
+
+Comment-like sequences inside strings stay part of the string — `"http://example.com"` is not
+truncated at the `//`.
 
 The executable formats are the escape hatch for config that has to be computed:
 
@@ -113,6 +134,67 @@ export default {
   presets: process.env.CI ? 'ci' : 'recommended'
 }
 ```
+
+[JSONC]: https://code.visualstudio.com/docs/languages/json#_json-with-comments
+
+## Inspecting the resolved config
+
+A CLI that accepts config gets a `--show-config` option, which prints the config it resolved and the
+file it came from:
+
+```sh
+$ app --show-config
+config: /home/me/project/app.jsonc
+{
+  "presets": "recommended"
+}
+```
+
+When the config came from `package.json`, the property is named too:
+
+```sh
+config: /home/me/project/package.json (property "app")
+```
+
+And when nothing matched, `--show-config` says so, after the warning listing every filename that was
+searched for:
+
+```sh
+config: not found
+```
+
+## Reading the config yourself
+
+`clibuilder` exports its config resolution, so a plugin or a tool can ask the same questions the CLI
+asks — including *where* an answer came from.
+
+```ts
+import { lookupConfig, resolveConfig } from 'clibuilder'
+
+// where would the config come from? (no file is read)
+const { source, candidates } = lookupConfig({ cwd: process.cwd() }, 'app')
+
+// the config plus its provenance
+const { config } = await resolveConfig({ cwd: process.cwd(), ui }, 'app')
+```
+
+`source` is one of:
+
+| `source.type` | Fields | Meaning |
+| --- | --- | --- |
+| `file` | `path`, `format` | a config file matched |
+| `package.json` | `path`, `property` | the `package.json` fallback was used |
+| `none` | — | nothing matched |
+
+`candidates` is every filename that was searched for, in priority order.
+
+Also exported: `loadConfig` (the config value alone), `readConfigFile` (parse one known file),
+`getConfigFilenames`, `getConfigFormat`, and `describeConfigSource` (render a `source` as one line).
+
+:::note
+These are read-only. Writing config back to disk is not supported yet — see
+[#488](https://github.com/clibuilder/clibuilder/issues/488).
+:::
 
 ## The `plugins` key
 

--- a/packages/clibuilder/fixtures/has-jsonc-config/bin.js
+++ b/packages/clibuilder/fixtures/has-jsonc-config/bin.js
@@ -1,0 +1,13 @@
+const { cli } = require('clibuilder')
+
+const app = cli({
+	name: 'show-config',
+	version: '1.0.0',
+	config: true
+}).default({
+	run() {
+		return this.ui.info(JSON.stringify(this.config))
+	}
+})
+
+app.parse(process.argv)

--- a/packages/clibuilder/fixtures/has-jsonc-config/package.json
+++ b/packages/clibuilder/fixtures/has-jsonc-config/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "has-jsonc-config",
+	"private": true,
+	"type": "commonjs",
+	"dependencies": {
+		"clibuilder": "workspace:*"
+	}
+}

--- a/packages/clibuilder/fixtures/has-jsonc-config/show-config.jsonc
+++ b/packages/clibuilder/fixtures/has-jsonc-config/show-config.jsonc
@@ -1,0 +1,5 @@
+{
+	// a line comment, which is not valid YAML
+	/* and a block comment */
+	"a": 1
+}

--- a/packages/clibuilder/fixtures/has-rc-jsonc-config/bin.js
+++ b/packages/clibuilder/fixtures/has-rc-jsonc-config/bin.js
@@ -1,0 +1,13 @@
+const { cli } = require('clibuilder')
+
+const app = cli({
+	name: 'show-config',
+	version: '1.0.0',
+	config: true
+}).default({
+	run() {
+		return this.ui.info(JSON.stringify(this.config))
+	}
+})
+
+app.parse(process.argv)

--- a/packages/clibuilder/fixtures/has-rc-jsonc-config/package.json
+++ b/packages/clibuilder/fixtures/has-rc-jsonc-config/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "has-rc-jsonc-config",
+	"private": true,
+	"type": "commonjs",
+	"dependencies": {
+		"clibuilder": "workspace:*"
+	}
+}

--- a/packages/clibuilder/fixtures/has-rc-jsonc-config/show-configrc.jsonc
+++ b/packages/clibuilder/fixtures/has-rc-jsonc-config/show-configrc.jsonc
@@ -1,0 +1,4 @@
+{
+	// a line comment, which is not valid YAML
+	"a": 1
+}

--- a/packages/clibuilder/package.json
+++ b/packages/clibuilder/package.json
@@ -50,7 +50,7 @@
 	],
 	"scripts": {
 		"build": "run-p build:cjs build:esm",
-		"build:cjs": "esbuild ts/index.ts ts/compile_cache.ts --bundle --platform=node --outdir=cjs && ncp package.cjs.json cjs/package.json",
+		"build:cjs": "esbuild ts/index.ts ts/compile_cache.ts --bundle --platform=node --alias:jsonc-parser=jsonc-parser/lib/esm/main.js --outdir=cjs && ncp package.cjs.json cjs/package.json",
 		"build:esm": "tsc",
 		"build:watch": "tsc --watch",
 		"clean": "rimraf .nyc_output .ts coverage cjs esm lib libm",
@@ -65,6 +65,7 @@
 	"dependencies": {
 		"find-installed-packages": "^3.1.1",
 		"js-yaml": "^4.1.1",
+		"jsonc-parser": "^3.3.1",
 		"pad-right": "^0.2.2",
 		"search-packages": "^2.2.0",
 		"standard-log": "^12.1.1",

--- a/packages/clibuilder/ts/builder.spec.ts
+++ b/packages/clibuilder/ts/builder.spec.ts
@@ -3,7 +3,7 @@ import { assertType, type IsExtend, required, testType } from 'type-plus'
 import { builder } from './builder.js'
 import { mockContext } from './context.mock.js'
 import { type cli, command, z } from './index.js'
-import { argv } from './test-utils/index.js'
+import { argv, getFixturePath } from './test-utils/index.js'
 
 function setupBuilderTest(contextParams?: mockContext.Params, options?: Partial<cli.Options>) {
 	const opt = required({ name: 'test-cli', version: '1.0.0' }, options)
@@ -573,3 +573,45 @@ Options:
   [--debug-cli]          Display clibuilder debug messages
 `
 }
+
+describe('--show-config (#317)', () => {
+	it('prints the config and the file it was loaded from', async () => {
+		const ctx = mockContext({ fixtureDir: 'has-json-config' })
+		await builder(ctx, { name: 'show-config', version: '1.0.0', config: true }).parse(argv('show-config --show-config'))
+
+		const msg = ctx.sl.reporter.getLogMessage()
+		expect(msg).toContain(`config: ${getFixturePath('has-json-config')}`)
+		expect(msg).toContain('show-config.json')
+		expect(msg).toContain('"a": 1')
+	})
+
+	it('reports the package.json fallback as the source', async () => {
+		const ctx = mockContext({ fixtureDir: 'has-pjson-config' })
+		await builder(ctx, { name: 'show-config', version: '1.0.0', config: true }).parse(argv('show-config --show-config'))
+
+		const msg = ctx.sl.reporter.getLogMessage()
+		expect(msg).toContain('package.json (property "show-config")')
+		expect(msg).toContain('"a": 1')
+	})
+
+	it('reports that no config was found', async () => {
+		const [builder, ctx] = setupBuilderTest(undefined, { config: true })
+		await builder.default({ run() {} }).parse(argv('test-cli --show-config'))
+
+		expect(ctx.sl.reporter.getLogMessage()).toContain('config: not found')
+	})
+
+	it('is offered by a cli that accepts config', async () => {
+		const [builder, ctx] = setupBuilderTest(undefined, { config: true })
+		await builder.default({ run() {} }).parse(argv('test-cli --help'))
+
+		expect(ctx.sl.reporter.getLogMessage()).toContain('[--show-config]')
+	})
+
+	it('is not offered by a cli that does not accept config', async () => {
+		const [builder, ctx] = setupBuilderTest()
+		await builder.default({ run() {} }).parse(argv('test-cli --help'))
+
+		expect(ctx.sl.reporter.getLogMessage()).not.toContain('show-config')
+	})
+})

--- a/packages/clibuilder/ts/builder.ts
+++ b/packages/clibuilder/ts/builder.ts
@@ -74,10 +74,7 @@ export function builder(context: Context, options: cli.Options): cli.Builder & c
 		context.ui.displayLevel = s.displayLevel
 		context.ui.dump()
 
-		if (s.configName && baseArgs['show-config']) {
-			delete rawArgs['show-config']
-			return showConfig(s.configName)
-		}
+		if (s.configName && baseArgs['show-config']) return showConfig(s.configName)
 
 		const r = lookupCommand(s.command, rawArgs)
 		const { args, command } = r

--- a/packages/clibuilder/ts/builder.ts
+++ b/packages/clibuilder/ts/builder.ts
@@ -3,6 +3,7 @@ import { parseArgv } from './argv.js'
 import type { cli } from './cli.js'
 import type { Command } from './command.internal.types.js'
 import { getBaseCommand, pluginsCommand } from './commands.js'
+import { describeConfigSource } from './config.js'
 import type { Context } from './context.js'
 import { lookupCommand } from './lookup_command.js'
 import { state } from './state.js'
@@ -57,7 +58,7 @@ export function builder(context: Context, options: cli.Options): cli.Builder & c
 		await Promise.all(pending)
 		context.ui.debug('argv:', argv.join(' '))
 		const rawArgs = parseArgv(argv)
-		const { args: baseArgs } = lookupCommand(getBaseCommand(s.description), rawArgs)
+		const { args: baseArgs } = lookupCommand(getBaseCommand(s.description, { config: !!s.configName }), rawArgs)
 		if (baseArgs.silent) {
 			delete rawArgs.silent
 			s.displayLevel = 'none'
@@ -72,6 +73,11 @@ export function builder(context: Context, options: cli.Options): cli.Builder & c
 		}
 		context.ui.displayLevel = s.displayLevel
 		context.ui.dump()
+
+		if (s.configName && baseArgs['show-config']) {
+			delete rawArgs['show-config']
+			return showConfig(s.configName)
+		}
 
 		const r = lookupCommand(s.command, rawArgs)
 		const { args, command } = r
@@ -95,6 +101,20 @@ export function builder(context: Context, options: cli.Options): cli.Builder & c
 		const commandInstance = createCommandInstance(context, s, command)
 		if (!commandInstance.run || args.help) return commandInstance.ui.showHelp()
 		return commandInstance.run(args as any)
+	}
+
+	/**
+	 * Reports the resolved config and its provenance.
+	 *
+	 * The resolution itself is `context.resolveConfig`, the same call the cli
+	 * already makes to load its config, so this reports what the cli actually
+	 * uses rather than re-deriving it.
+	 */
+	async function showConfig(configName: string) {
+		const { config, source } = await context.resolveConfig(configName)
+		const ui = createCommandUI(context, s, s.command)
+		ui.info(`config: ${describeConfigSource(source)}`)
+		if (source.type !== 'none') ui.info(JSON.stringify(config, undefined, 2))
 	}
 
 	function parseConfig(configType: z.ZodTypeAny, config: any) {

--- a/packages/clibuilder/ts/commands.ts
+++ b/packages/clibuilder/ts/commands.ts
@@ -14,7 +14,12 @@ const findByKeywords: typeof import('find-installed-packages').findByKeywords = 
 const searchByKeywords: typeof import('search-packages').searchByKeywords = async (...args: any[]): Promise<any> =>
 	(await import('search-packages')).searchByKeywords(...(args as [string[]]))
 
-export function getBaseCommand(description: string) {
+/**
+ * @param options.config whether the cli accepts configuration.
+ * `--show-config` is only offered when it does, so a cli without config
+ * does not advertise an option that could never do anything.
+ */
+export function getBaseCommand(description: string, options?: { config?: boolean }) {
 	return command({
 		name: '',
 		description,
@@ -41,7 +46,15 @@ export function getBaseCommand(description: string) {
 			'debug-cli': {
 				type: z.optional(z.boolean()),
 				description: 'Display clibuilder debug messages'
-			}
+			},
+			...(options?.config
+				? {
+						'show-config': {
+							type: z.optional(z.boolean()),
+							description: 'Print the resolved config and where it was loaded from'
+						}
+					}
+				: {})
 		},
 		commands: [],
 		run() {

--- a/packages/clibuilder/ts/config.spec.ts
+++ b/packages/clibuilder/ts/config.spec.ts
@@ -148,6 +148,14 @@ describe('jsonc config (#341)', () => {
 		expect(await loadConfig({ cwd, ui }, name)).toEqual({ a: 1 })
 	})
 
+	// an extension-less file carries no format hint, so YAML content still has to work
+	it('falls back to YAML for an extension-less rc file that is not JSON', async () => {
+		const name = nextConfigName()
+		const { cwd } = scaffold({ [`.${name}rc`]: 'a: 1\nb: two\n' })
+
+		expect(await loadConfig({ cwd, ui }, name)).toEqual({ a: 1, b: 'two' })
+	})
+
 	// a regex-based comment stripper truncates this value at the `//` of the url
 	it('does not treat a comment-like sequence inside a string as a comment', async () => {
 		const name = nextConfigName()
@@ -254,5 +262,23 @@ describe('resolveConfig() (#488)', () => {
 		const { config, source } = await resolveConfig({ cwd, ui }, name)
 		expect(config).toBeUndefined()
 		expect(source).toEqual({ type: 'none' })
+	})
+})
+
+describe('getConfigFilenames()', () => {
+	it('skips the dotted variants when the config name already starts with a dot', () => {
+		const candidates = getConfigFilenames('.app')
+
+		expect(candidates).toContain('.app.json')
+		expect(candidates).not.toContain('..app.json')
+	})
+})
+
+describe('module config', () => {
+	it('loads a `.cjs` config through its export', async () => {
+		const name = nextConfigName()
+		const { cwd } = scaffold({ [`${name}.cjs`]: 'module.exports = { a: 1 }\n' })
+
+		expect(await loadConfig({ cwd, ui }, name)).toEqual({ a: 1 })
 	})
 })

--- a/packages/clibuilder/ts/config.spec.ts
+++ b/packages/clibuilder/ts/config.spec.ts
@@ -2,7 +2,14 @@ import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { baseline, execCommand } from '@unional/fixture'
-import { loadConfig } from './config.js'
+import {
+	getConfigFilenames,
+	getConfigFormat,
+	loadConfig,
+	lookupConfig,
+	readConfigFile,
+	resolveConfig
+} from './config.js'
 
 baseline(
 	{
@@ -21,37 +28,37 @@ baseline(
 	}
 )
 
+const ui = { info() {}, debug() {}, warn() {} }
+const roots: string[] = []
+
+// each case uses its own config name so nothing above `tmpdir()` can match
+let counter = 0
+function nextConfigName() {
+	return `clibuilder-spec-${process.pid}-${counter++}`
+}
+
+/**
+ * Creates `<root>/a/b/c` and writes each entry of `files` relative to `root`.
+ * Returns the root and the deepest directory to look up from.
+ */
+function scaffold(files: Record<string, string>) {
+	const root = mkdtempSync(join(tmpdir(), 'clibuilder-config-'))
+	roots.push(root)
+	const cwd = join(root, 'a', 'b', 'c')
+	mkdirSync(cwd, { recursive: true })
+	// a `package.json` at the root stops the `package.json` fallback from escaping the scaffold
+	writeFileSync(join(root, 'package.json'), '{}')
+	for (const [name, content] of Object.entries(files)) {
+		writeFileSync(join(root, name), content)
+	}
+	return { root, cwd }
+}
+
+afterAll(() => {
+	for (const root of roots) rmSync(root, { recursive: true, force: true })
+})
+
 describe('loadConfig() lookup', () => {
-	const ui = { info() {}, debug() {}, warn() {} }
-	const roots: string[] = []
-
-	// each case uses its own config name so nothing above `tmpdir()` can match
-	let counter = 0
-	function nextConfigName() {
-		return `clibuilder-spec-${process.pid}-${counter++}`
-	}
-
-	/**
-	 * Creates `<root>/a/b/c` and writes each entry of `files` relative to `root`.
-	 * Returns the root and the deepest directory to look up from.
-	 */
-	function scaffold(files: Record<string, string>) {
-		const root = mkdtempSync(join(tmpdir(), 'clibuilder-config-'))
-		roots.push(root)
-		const cwd = join(root, 'a', 'b', 'c')
-		mkdirSync(cwd, { recursive: true })
-		// a `package.json` at the root stops the `package.json` fallback from escaping the scaffold
-		writeFileSync(join(root, 'package.json'), '{}')
-		for (const [name, content] of Object.entries(files)) {
-			writeFileSync(join(root, name), content)
-		}
-		return { root, cwd }
-	}
-
-	afterAll(() => {
-		for (const root of roots) rmSync(root, { recursive: true, force: true })
-	})
-
 	it('finds the config in an ancestor directory', async () => {
 		const name = nextConfigName()
 		const { cwd } = scaffold({ [`${name}.json`]: '{"from":"root"}' })
@@ -114,5 +121,138 @@ describe('loadConfig() lookup', () => {
 		const { cwd } = scaffold({})
 
 		expect(await loadConfig({ cwd, ui }, name)).toBeUndefined()
+	})
+})
+
+describe('jsonc config (#341)', () => {
+	it('parses a `.jsonc` file with line and block comments and a trailing comma', async () => {
+		const name = nextConfigName()
+		const { cwd } = scaffold({
+			[`${name}.jsonc`]: '{\n\t// a line comment\n\t/* a block comment */\n\t"a": 1,\n}'
+		})
+
+		expect(await loadConfig({ cwd, ui }, name)).toEqual({ a: 1 })
+	})
+
+	it('parses comments in a `.json` file too', async () => {
+		const name = nextConfigName()
+		const { cwd } = scaffold({ [`${name}.json`]: '{\n\t// a line comment\n\t"a": 1\n}' })
+
+		expect(await loadConfig({ cwd, ui }, name)).toEqual({ a: 1 })
+	})
+
+	it('parses comments in an extension-less rc file', async () => {
+		const name = nextConfigName()
+		const { cwd } = scaffold({ [`.${name}rc`]: '{\n\t// a line comment\n\t"a": 1\n}' })
+
+		expect(await loadConfig({ cwd, ui }, name)).toEqual({ a: 1 })
+	})
+
+	// a regex-based comment stripper truncates this value at the `//` of the url
+	it('does not treat a comment-like sequence inside a string as a comment', async () => {
+		const name = nextConfigName()
+		const { cwd } = scaffold({ [`${name}.jsonc`]: '{ "a": "http://example.com/x" /* trailing */ }' })
+
+		expect(await loadConfig({ cwd, ui }, name)).toEqual({ a: 'http://example.com/x' })
+	})
+
+	it('offers `.jsonc` and `rc.jsonc` as candidates, dot-prefixed too', () => {
+		const candidates = getConfigFilenames('my-cli')
+
+		expect(candidates).toContain('my-cli.jsonc')
+		expect(candidates).toContain('.my-cli.jsonc')
+		expect(candidates).toContain('my-clirc.jsonc')
+		expect(candidates).toContain('.my-clirc.jsonc')
+	})
+
+	it('reports the file that failed instead of parsing it into an empty object', async () => {
+		const name = nextConfigName()
+		const { root } = scaffold({ [`${name}.json`]: '{ this is not json at all' })
+
+		await expect(readConfigFile(join(root, `${name}.json`))).rejects.toThrow(/Unable to parse .* as JSON/)
+	})
+
+	it.each([
+		['a.json', 'jsonc'],
+		['a.jsonc', 'jsonc'],
+		['a.yml', 'yaml'],
+		['a.yaml', 'yaml'],
+		['a.js', 'module'],
+		['a.cjs', 'module'],
+		['a.mjs', 'module'],
+		['.my-clirc', 'unknown']
+	])('%s is parsed as %s', (path, format) => {
+		expect(getConfigFormat(path)).toEqual(format)
+	})
+})
+
+describe('lookupConfig() provenance (#488)', () => {
+	it('reports the matched file and its format without reading it', () => {
+		const name = nextConfigName()
+		const { root, cwd } = scaffold({ [`${name}.jsonc`]: '{"a":1}' })
+
+		expect(lookupConfig({ cwd }, name).source).toEqual({
+			type: 'file',
+			path: join(root, `${name}.jsonc`),
+			format: 'jsonc'
+		})
+	})
+
+	it('reports the package.json fallback and the property it read', () => {
+		const name = nextConfigName()
+		const { root, cwd } = scaffold({})
+		writeFileSync(join(root, 'package.json'), JSON.stringify({ [name]: { a: 1 } }))
+
+		expect(lookupConfig({ cwd }, name).source).toEqual({
+			type: 'package.json',
+			path: join(root, 'package.json'),
+			property: name
+		})
+	})
+
+	it('reports `none` when nothing matched', () => {
+		const name = nextConfigName()
+		const { cwd } = scaffold({})
+
+		expect(lookupConfig({ cwd }, name).source).toEqual({ type: 'none' })
+	})
+
+	it('reports the candidates it searched for', () => {
+		const name = nextConfigName()
+		const { cwd } = scaffold({})
+
+		expect(lookupConfig({ cwd }, name).candidates).toEqual(getConfigFilenames(name))
+	})
+})
+
+describe('resolveConfig() (#488)', () => {
+	it('returns the config together with the file it came from', async () => {
+		const name = nextConfigName()
+		const { root, cwd } = scaffold({ [`${name}.json`]: '{"a":1}' })
+
+		expect(await resolveConfig({ cwd, ui }, name)).toEqual({
+			config: { a: 1 },
+			source: { type: 'file', path: join(root, `${name}.json`), format: 'jsonc' },
+			candidates: getConfigFilenames(name)
+		})
+	})
+
+	it('returns the config together with the package.json it came from', async () => {
+		const name = nextConfigName()
+		const { root, cwd } = scaffold({})
+		writeFileSync(join(root, 'package.json'), JSON.stringify({ [name]: { a: 1 } }))
+
+		const { config, source } = await resolveConfig({ cwd, ui }, name)
+		expect(config).toEqual({ a: 1 })
+		expect(source).toEqual({ type: 'package.json', path: join(root, 'package.json'), property: name })
+	})
+
+	it('returns an undefined config with a `none` source when nothing matched', async () => {
+		const name = nextConfigName()
+		const { cwd } = scaffold({})
+
+		const { config, source } = await resolveConfig({ cwd, ui }, name)
+		expect(config).toBeUndefined()
+		expect(source).toEqual({ type: 'none' })
 	})
 })

--- a/packages/clibuilder/ts/config.ts
+++ b/packages/clibuilder/ts/config.ts
@@ -188,6 +188,9 @@ export async function readConfigFile(configFilePath: string) {
 		try {
 			return yaml.load(content)
 		} catch {
+			// ignoring coverage. An extension-less module config cannot be `import()`ed by name,
+			// so this is only reachable for a file `node` can already resolve.
+			// istanbul ignore next
 			return readModuleConfig(configFilePath)
 		}
 	}

--- a/packages/clibuilder/ts/config.ts
+++ b/packages/clibuilder/ts/config.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs'
+import { extname } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import yaml from 'js-yaml'
+import { type ParseError, parse as parseJsonc, printParseErrorCode } from 'jsonc-parser'
 import type { UI } from './cli.js'
 import { findAnyFileUp } from './find_up.js'
 import { findPackageJson, getPackageJson } from './platform.js'
@@ -8,6 +10,95 @@ import { findPackageJson, getPackageJson } from './platform.js'
 export const ctx = {
 	findPackageJson,
 	getPackageJson
+}
+
+/**
+ * How a config file's content is parsed.
+ *
+ * - `jsonc`: JSON with comments and trailing commas (`.json`, `.jsonc`).
+ * - `yaml`: `.yml` / `.yaml`.
+ * - `module`: `.js` / `.cjs` / `.mjs`, loaded through `import()`.
+ * - `unknown`: an extension-less candidate such as `.<name>rc`,
+ *   whose content decides the format.
+ */
+export type ConfigFormat = 'jsonc' | 'yaml' | 'module' | 'unknown'
+
+/**
+ * Where a config value came from.
+ *
+ * `type: 'none'` means nothing matched, which is distinct from a config file
+ * that exists and holds `undefined`.
+ */
+export type ConfigSource =
+	| { type: 'file'; path: string; format: ConfigFormat }
+	| { type: 'package.json'; path: string; property: string }
+	| { type: 'none' }
+
+export type ConfigLookupResult = {
+	source: ConfigSource
+	/**
+	 * The file names searched for, in priority order, at every directory
+	 * from `cwd` up to the filesystem root.
+	 */
+	candidates: string[]
+}
+
+export type ConfigLoadResult = ConfigLookupResult & { config: any }
+
+/**
+ * Finds where the config for `configName` would be read from, without reading it.
+ *
+ * Prefers a config file in the nearest ancestor directory. Falls back to the
+ * `configName` property of the nearest `package.json`, and reports
+ * `{ type: 'none' }` when neither exists.
+ */
+export function lookupConfig({ cwd }: { cwd: string }, configName: string): ConfigLookupResult {
+	const candidates = getConfigFilenames(configName)
+	const path = findAnyFileUp(cwd, candidates)
+	if (path) return { source: { type: 'file', path, format: getConfigFormat(path) }, candidates }
+
+	const pjsonPath = ctx.findPackageJson(cwd)
+	if (pjsonPath) {
+		const pjson = ctx.getPackageJson(pjsonPath)
+		if (pjson[configName]) {
+			return { source: { type: 'package.json', path: pjsonPath, property: configName }, candidates }
+		}
+	}
+	return { source: { type: 'none' }, candidates }
+}
+
+/**
+ * Loads the config for `configName` along with where it came from.
+ *
+ * This is the provenance-carrying form of {@link loadConfig}; use it when the
+ * caller needs to report or act on the origin of the config, not just its value.
+ */
+export async function resolveConfig(
+	{
+		cwd,
+		ui
+	}: {
+		cwd: string
+		ui: Pick<UI, 'info' | 'debug' | 'warn'>
+	},
+	configName: string
+): Promise<ConfigLoadResult> {
+	const { source, candidates } = lookupConfig({ cwd }, configName)
+	if (source.type === 'file') {
+		ui.debug(`load config from: ${source.path}`)
+		const config = await readConfigFile(source.path)
+		ui.debug(`config: ${JSON.stringify(config, undefined, 2)}`)
+		return { config, source, candidates }
+	}
+	if (source.type === 'package.json') {
+		ui.debug(`load config from package.json: ${source.path}`)
+		const pjson = ctx.getPackageJson(source.path)
+		const config = pjson[source.property]
+		ui.debug(`config: ${JSON.stringify(config, undefined, 2)}`)
+		return { config, source, candidates }
+	}
+	ui.warn(`no config found under '${cwd}':\n  ${candidates.join('\n  ')}`)
+	return { config: undefined, source, candidates }
 }
 
 export async function loadConfig(
@@ -20,36 +111,38 @@ export async function loadConfig(
 	},
 	configName: string
 ) {
-	const configFileNames = getConfigFilenames(configName)
-	const configFilePath = findAnyFileUp(cwd, configFileNames)
-	if (configFilePath) {
-		ui.debug(`load config from: ${configFilePath}`)
-		const cfg = await readConfig(configFilePath)
-		ui.debug(`config: ${JSON.stringify(cfg, undefined, 2)}`)
-		return cfg
-	}
-	const pjsonPath = ctx.findPackageJson(cwd)
-	if (pjsonPath) {
-		ui.debug(`load config from package.json: ${pjsonPath}`)
-		const pjson = ctx.getPackageJson(pjsonPath)
-		if (pjson[configName]) return pjson[configName]
-	}
-	ui.warn(`no config found under '${cwd}':\n  ${configFileNames.join('\n  ')}`)
+	return (await resolveConfig({ cwd, ui }, configName)).config
 }
 
-function getConfigFilenames(configFileName: string) {
+/**
+ * Renders a {@link ConfigSource} as a single human-readable line.
+ */
+export function describeConfigSource(source: ConfigSource) {
+	switch (source.type) {
+		case 'file':
+			return source.path
+		case 'package.json':
+			return `${source.path} (property "${source.property}")`
+		default:
+			return 'not found'
+	}
+}
+
+export function getConfigFilenames(configFileName: string) {
 	const names = [
 		configFileName,
 		`${configFileName}.cjs`,
 		`${configFileName}.mjs`,
 		`${configFileName}.js`,
 		`${configFileName}.json`,
+		`${configFileName}.jsonc`,
 		`${configFileName}.yml`,
 		`${configFileName}.yaml`,
 		`${configFileName}rc.cjs`,
 		`${configFileName}rc.mjs`,
 		`${configFileName}rc.js`,
 		`${configFileName}rc.json`,
+		`${configFileName}rc.jsonc`,
 		`${configFileName}rc.yml`,
 		`${configFileName}rc.yaml`,
 		`${configFileName}rc`
@@ -57,19 +150,69 @@ function getConfigFilenames(configFileName: string) {
 	return configFileName.startsWith('.') ? names : names.flatMap((n) => [n, `.${n}`])
 }
 
-// ignoring coverage. Test are done through `@unional/fixture` `execCommand()`
-// istanbul ignore next
-async function readConfig(configFilePath: string) {
+export function getConfigFormat(configFilePath: string): ConfigFormat {
+	switch (extname(configFilePath).toLowerCase()) {
+		case '.json':
+		case '.jsonc':
+			return 'jsonc'
+		case '.yml':
+		case '.yaml':
+			return 'yaml'
+		case '.js':
+		case '.cjs':
+		case '.mjs':
+			return 'module'
+		default:
+			// extension-less candidates such as `.<name>rc` carry no format hint
+			return 'unknown'
+	}
+}
+
+/**
+ * Reads and parses a single config file, dispatching on its extension.
+ *
+ * An extension-less file has its format inferred from its content, trying the
+ * same order the candidate list implies: JSON(C), then YAML, then module.
+ */
+export async function readConfigFile(configFilePath: string) {
+	const format = getConfigFormat(configFilePath)
+	if (format === 'module') return readModuleConfig(configFilePath)
+
 	const content = readFileSync(configFilePath, 'utf-8')
+	if (format === 'jsonc') return parseJsoncOrThrow(content, configFilePath)
+	if (format === 'yaml') return yaml.load(content)
+
 	try {
-		return JSON.parse(content)
+		return parseJsoncOrThrow(content, configFilePath)
 	} catch {
 		try {
 			return yaml.load(content)
 		} catch {
-			const m = await import(pathToFileURL(configFilePath).href)
-			if (m.activate) return m
-			return m.default
+			return readModuleConfig(configFilePath)
 		}
 	}
+}
+
+// ignoring coverage. Test are done through `@unional/fixture` `execCommand()`
+// istanbul ignore next
+async function readModuleConfig(configFilePath: string) {
+	const m = await import(pathToFileURL(configFilePath).href)
+	if (m.activate) return m
+	return m.default
+}
+
+/**
+ * `jsonc-parser` recovers from syntax errors instead of throwing — a JS module
+ * parses to `{}` and a YAML list to its first scalar. The `errors` array is the
+ * only reliable signal, so a non-empty one has to become a throw for the
+ * format-inference fallback above to work.
+ */
+function parseJsoncOrThrow(content: string, configFilePath: string) {
+	const errors: ParseError[] = []
+	const value = parseJsonc(content, errors, { allowTrailingComma: true, disallowComments: false })
+	if (errors.length > 0) {
+		const [{ error, offset }] = errors
+		throw new Error(`Unable to parse ${configFilePath} as JSON: ${printParseErrorCode(error)} at offset ${offset}`)
+	}
+	return value
 }

--- a/packages/clibuilder/ts/context.mock.ts
+++ b/packages/clibuilder/ts/context.mock.ts
@@ -2,7 +2,7 @@ import { type LogLevel, logLevels } from 'standard-log'
 import { createStandardLogForTest, type StandardLogForTest } from 'standard-log/testing'
 import tmp from 'tmp'
 import { required } from 'type-plus'
-import { loadConfig } from './config.js'
+import { type ConfigLoadResult, resolveConfig } from './config.js'
 import type { Context } from './context.js'
 import { loadPlugins } from './plugins.js'
 import { getFixturePath } from './test-utils/index.js'
@@ -18,7 +18,10 @@ export function mockContext(params?: mockContext.Params): Context & { sl: Standa
 	const sl = createStandardLogForTest({ logLevel })
 	return {
 		async loadConfig(configName: string) {
-			return loadConfig({ cwd, ui: this.ui }, configName)
+			return (await this.resolveConfig(configName)).config
+		},
+		async resolveConfig(configName: string): Promise<ConfigLoadResult> {
+			return resolveConfig({ cwd, ui: this.ui }, configName)
 		},
 		async loadPlugins(pluginNames: string[]) {
 			return loadPlugins({ cwd, ui: this.ui }, pluginNames)

--- a/packages/clibuilder/ts/context.ts
+++ b/packages/clibuilder/ts/context.ts
@@ -1,7 +1,7 @@
 import { createConsoleLogReporter, createStandardLog, logLevels } from 'standard-log'
 import { createColorLogReporter } from 'standard-log-color'
 import type { Command } from './command.internal.types.js'
-import { loadConfig } from './config.js'
+import { type ConfigLoadResult, resolveConfig } from './config.js'
 import { loadPlugins } from './plugins.js'
 import { createBuilderUI, createUI } from './ui.js'
 
@@ -17,12 +17,20 @@ export function context() {
 		logLevel: logLevels.all,
 		reporters: [createConsoleLogReporter()]
 	})
-	let config: any
+	// the resolution is cached as a promise so concurrent callers share one filesystem walk,
+	// and so a config that is legitimately falsy is not re-resolved on every call.
+	let resolvingConfig: Promise<ConfigLoadResult>
 	let loadingCommands: Promise<Command[]>
 	return {
 		async loadConfig(configName: string) {
-			if (config) return config
-			return (config = await loadConfig({ cwd, ui: this.ui }, configName))
+			return (await this.resolveConfig(configName)).config
+		},
+		/**
+		 * Resolves the config along with where it came from.
+		 */
+		async resolveConfig(configName: string): Promise<ConfigLoadResult> {
+			if (resolvingConfig) return resolvingConfig
+			return (resolvingConfig = resolveConfig({ cwd, ui: this.ui }, configName))
 		},
 		// ignoring coverage. Test are done through `@unional/fixture` `execCommand()`
 		// istanbul ignore next

--- a/packages/clibuilder/ts/index.ts
+++ b/packages/clibuilder/ts/index.ts
@@ -1,5 +1,18 @@
 export * from './argv.js'
 export * from './cli.js'
 export * from './command.js'
+export {
+	type ConfigFormat,
+	type ConfigLoadResult,
+	type ConfigLookupResult,
+	type ConfigSource,
+	describeConfigSource,
+	getConfigFilenames,
+	getConfigFormat,
+	loadConfig,
+	lookupConfig,
+	readConfigFile,
+	resolveConfig
+} from './config.js'
 export * from './testing/test_command.js'
 export * from './zod.js'

--- a/packages/clibuilder/ts/state.ts
+++ b/packages/clibuilder/ts/state.ts
@@ -27,6 +27,6 @@ export function state(options: cli.Options): state.Result {
 		configName,
 		keywords,
 		displayLevel: 'info',
-		command: getBaseCommand(description) as any
+		command: getBaseCommand(description, { config: !!configName }) as any
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       pad-right:
         specifier: ^0.2.2
         version: 0.2.2
@@ -418,6 +421,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  packages/clibuilder/fixtures/has-jsonc-config:
+    dependencies:
+      clibuilder:
+        specifier: workspace:*
+        version: link:../..
+
   packages/clibuilder/fixtures/has-mjs-config:
     dependencies:
       clibuilder:
@@ -443,6 +452,12 @@ importers:
         version: link:../..
 
   packages/clibuilder/fixtures/has-rc-json-config:
+    dependencies:
+      clibuilder:
+        specifier: workspace:*
+        version: link:../..
+
+  packages/clibuilder/fixtures/has-rc-jsonc-config:
     dependencies:
       clibuilder:
         specifier: workspace:*


### PR DESCRIPTION
Reworks the config subsystem around a single resolution that carries **where** the config came from,
then builds the three requested features on it.

Closes #341
Closes #317

Partially addresses #488 — the read/lookup half ships here; the write half is analysed in a comment
on that issue and deliberately left out. Details below.

## #341 — jsonc

Confirmed as a real bug before fixing. Two independent failures:

- `.jsonc` was not in the candidate list at all, so a `.jsonc` file was never found.
- A `//` comment is not valid YAML, so the old `JSON.parse` → `yaml.load` → `import()` chain failed
  on a commented file. (Trailing commas already happened to survive, via YAML.)

Fixed with [`jsonc-parser`](https://github.com/microsoft/node-jsonc-parser) rather than a regex
comment stripper, so trailing commas and comment-like sequences inside strings behave. There is a
test asserting `"http://example.com/x"` is not truncated at the `//`.

One sharp edge worth flagging for review: `jsonc-parser` **recovers** from syntax errors instead of
throwing — a JS module parses to `{}`, a YAML list to its first scalar. Its `errors` array is the
only reliable signal, so a non-empty one is converted to a throw. Without that, format inference for
extension-less files would silently succeed on the wrong parser.

**Behavior change:** format is now chosen by extension instead of trying every parser in turn.
Extension-less candidates (`.apprc`) still infer from content. So a malformed `.json` now reports a
parse error naming the file, where before it was silently retried as YAML and could load as
something unintended. Loud beats silently-wrong, but it is a change.

## #488 — lookup/load config API

**Exposed as standalone exports, not on the plugin activation context.** `PluginActivationContext`
lives in `ts/cli.ts`, which this branch does not own, so wiring config access into it is left as a
follow-up. The standalone form is usable from a plugin command today via `this.cwd`.

```ts
import { lookupConfig, resolveConfig } from 'clibuilder'

const { source, candidates } = lookupConfig({ cwd }, 'app')   // origin only, no file read
const { config, source } = await resolveConfig({ cwd, ui }, 'app')
```

`source` is a discriminated union — `{ type: 'file', path, format }`,
`{ type: 'package.json', path, property }`, or `{ type: 'none' }` — so "found nothing" is
distinguishable from "found a config holding `undefined`". Also exported: `loadConfig`,
`readConfigFile`, `getConfigFilenames`, `getConfigFormat`, `describeConfigSource`.

### On the write half — scoped out deliberately

The issue asks for read *and update*. Update is a genuine design decision, not an implementation
detail, so per the mission brief it is not guessed at here. Summary of why (full analysis posted on
#488):

- **Comment/format preservation.** A naive read-modify-write destroys comments in `.jsonc` and
  `.yaml`. Preserving them is tractable for JSON(C) — `jsonc-parser` has `modify`/`applyEdits`,
  already a dependency after this PR — but for YAML it requires replacing `js-yaml` with a
  document-model parser. That is a dependency swap affecting every YAML read, not a local change.
- **Sources that cannot be written back.** `.js`/`.cjs`/`.mjs` configs are code; there is no
  meaningful write. These have to fail loudly.
- **The `package.json` fallback** is a shared file, so writing means merging one property, not
  replacing the document.
- **Update semantics are unspecified** — deep merge vs. replace vs. set-at-path. Baking the wrong
  one into a published API is worse than shipping read-only now.

Shipping a writer that silently mangles comments would be exactly the data loss the brief warns
about, so the read half ships alone and #488 stays open for the write half.

## #317 — `--show-config`

A **global option on the base command**, alongside `--version`/`--verbose`, rather than a subcommand
— it is an inspection flag, and a subcommand would collide with plugin-contributed command names. It
is only added when the cli declares `config`, so a cli that cannot have config does not advertise a
flag that could never do anything (asserted both ways in tests).

Provenance is the point, so it reports the origin rather than just the value:

```
$ app --show-config
config: /home/me/project/app.jsonc
{
  "presets": "recommended"
}

$ app --show-config          # package.json fallback
config: /home/me/project/package.json (property "app")

$ app --show-config          # nothing found (after the existing warning listing candidates)
config: not found
```

It calls `context.resolveConfig` — the same resolution the cli already performs, cached — so it
reports what the cli actually uses instead of re-deriving it.

## Notes for the reviewer

- `build:cjs` gained `--alias:jsonc-parser=jsonc-parser/lib/esm/main.js`. esbuild resolves that
  package's `main` to a UMD bundle whose runtime `require` it cannot statically analyse, producing a
  cjs build that throws `Cannot find module './impl/format'`. The alias points it at the ESM entry.
  Scoped to this one dependency rather than flipping `main-fields` for everything.
- `context.loadConfig` now caches the resolution **promise** rather than the value, so concurrent
  callers share one filesystem walk and a legitimately falsy config is not re-resolved every call.
- Docs updated: the configuration guide's candidate list and format table were both stale after this
  change, plus new sections for `--show-config` and the read API.

## Verification

`pnpm build`, `pnpm test` (258 passing, up from 230), `pnpm lint`, `pnpm depcheck` all green
locally. New coverage: jsonc parsing and format dispatch, provenance for all three source kinds, and
`--show-config` output for each, including the gating both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
