### PR TITLE
feat(clibuilder)!: require node >= 20.19, update find-installed-packages to v4

### DIFF
--- a/.changeset/loud-pears-travel.md
+++ b/.changeset/loud-pears-travel.md
@@ -1,0 +1,17 @@
+---
+'clibuilder': major
+---
+
+Require Node.js >= 20.19 and update `find-installed-packages` to `^4.0.0`.
+
+`engines.node` moves from `>= 18` to `>= 20.19`, matching what
+`find-installed-packages@4` supports. Node 18 and 19 reached end of life, so
+there is no supported runtime left below that floor.
+
+v4 also changes how plugins are discovered. It walks the declared dependency
+graph and asks the runtime's module resolver where each package lives, instead
+of scanning `node_modules`. That fixes discovery under pnpm, Yarn Plug'n'Play,
+and workspaces where the tree is hoisted to the repo root. The trade-off: only
+*declared* dependencies are reported, so a plugin sitting in `node_modules` that
+nothing depends on is no longer found — add it to your `package.json`
+dependencies if you were relying on that.

--- a/apps/website/src/content/docs/getting-started/installation.md
+++ b/apps/website/src/content/docs/getting-started/installation.md
@@ -19,7 +19,7 @@ rush add -p clibuilder
 
 ## Requirements
 
-- **Node.js 18 or newer.**
+- **Node.js 20.19 or newer.**
 - **TypeScript is optional but recommended.** The type inference in `run(args)` is the main reason to
   use `clibuilder` over a hand-rolled parser; in plain JavaScript everything still works, you just
   don't see the inferred types.

--- a/packages/clibuilder/package.json
+++ b/packages/clibuilder/package.json
@@ -69,7 +69,7 @@
 		"w": "pnpm watch"
 	},
 	"dependencies": {
-		"find-installed-packages": "^3.1.1",
+		"find-installed-packages": "^4.0.0",
 		"js-yaml": "^4.1.1",
 		"jsonc-parser": "^3.3.1",
 		"pad-right": "^0.2.2",
@@ -114,6 +114,6 @@
 		"typescript": "^5.0.4"
 	},
 	"engines": {
-		"node": ">= 18"
+		"node": ">= 20.19"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ importers:
   packages/clibuilder:
     dependencies:
       find-installed-packages:
-        specifier: ^3.1.1
-        version: 3.1.1
+        specifier: ^4.0.0
+        version: 4.0.0
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -3303,6 +3303,10 @@ packages:
   find-installed-packages@3.1.1:
     resolution: {integrity: sha512-aFA7JbUCysD/ACS89o2hrEdgMtXV5mm+AJBxySQXGLe7Z+TzFw5YDFlI+6WAOSTKRqbkC5v105ToO0/krRn+4A==}
     engines: {bun: '>=1.0', node: '>=14'}
+
+  find-installed-packages@4.0.0:
+    resolution: {integrity: sha512-PKkQCxMpOrW1cHEE9oQOTvDOMD++Bw0HT+nQpWrhXQrairaQA4m+cDdosQjAmNGQ0lCkkGWuuPrksDXE9B7Cug==}
+    engines: {bun: '>=1.0', node: '>=20.19'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -8723,6 +8727,12 @@ snapshots:
 
   find-installed-packages@3.1.1:
     dependencies:
+      temp: 0.9.4
+      unpartial: 1.0.5
+
+  find-installed-packages@4.0.0:
+    dependencies:
+      package-manager-detector: 1.8.0
       temp: 0.9.4
       unpartial: 1.0.5
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,10 @@
 autoInstallPeers: true
 strictPeerDependencies: false
 
+# Packages we maintain ourselves, so the cooling-off period buys nothing.
+minimumReleaseAgeExclude:
+  - find-installed-packages
+
 packages:
   - apps/*
   - packages/*


### PR DESCRIPTION
Upgrades `find-installed-packages` to `^4.0.0` and raises `clibuilder`'s node floor to match.

## What changed

- **`find-installed-packages` 3.1.1 → 4.0.0.** The `findByKeywords(keywords, { cwd })` signature is unchanged, so no code edits were needed. v4 locates plugins by walking the declared dependency graph and asking the runtime's module resolver where each package lives, instead of scanning `node_modules`. That fixes discovery under pnpm, Yarn Plug'n'Play, and workspaces where the tree is hoisted to the repo root.
- **`engines.node` `>= 18` → `>= 20.19`**, which is what v4 supports. Node 18 and 19 are both end-of-life, so no supported runtime is dropped. The docs' Requirements section is updated to match.
- **`minimumReleaseAgeExclude`** in `pnpm-workspace.yaml` covers `find-installed-packages`, since we maintain it ourselves and the cooling-off period buys nothing against our own releases.
- Major changeset.

## Breaking changes

1. Requires node >= 20.19.
2. Only **declared** dependencies are discovered as plugins. A plugin sitting in `node_modules` that nothing depends on is no longer found, and needs to be added to `dependencies`.

## Verification

`pnpm install`, `pnpm build` (cjs + esm), `pnpm depcheck`, and the full clibuilder suite (290 passed, 17 suites) all clean locally.

## Note for a follow-up

The comment above the `website` job in `.github/workflows/pull-request.yml` says the shared verify matrix "still covers node 18." It doesn't — `clibuilder/.github`'s `pnpm-verify.yml` defaults to `["lts/-1", "lts/*"]` (Node 22 and 24). The stated reason for excluding the docs site from `verify:pkg` no longer holds. Left out of this PR; handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)