### PR TITLE
docs(ci): drop the stale comment on the website job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,8 +9,6 @@ jobs:
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  # The docs site is excluded from `verify:pkg` because astro needs node >= 22 and
-  # that matrix still covers node 18. Build it here on the repo's own node version.
   website:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Comment-only fix. No behavior change.

## The problem

The comment above the `website` job read:

> The docs site is excluded from `verify:pkg` because astro needs node >= 22 and that matrix still covers node 18. Build it here on the repo's own node version.

That is no longer true. `clibuilder/.github`'s `pnpm-verify.yml` defaults `node-version` to `["lts/-1", "lts/*"]` — currently Node 22 and 24 — so the matrix does not cover node 18, and astro's `>=22.12.0` floor is satisfied by every leg. Anyone reading the comment would conclude the exclusion is obsolete.

## The fix

Delete the comment. The job's steps read plainly on their own, and a comment restating them is one more thing to go stale.

The exclusion itself is still correct, for reasons the comment never gave: the site is a private app with no `coverage`, `depcheck`, or `size` to contribute; the verify matrix would rebuild it once per OS/node leg for no extra signal; and `verify:pkg` never runs `astro check`, which this job does via `pnpm web typecheck`.

Found while raising the node floor in #588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)