### PR TITLE
feat(clibuilder): union `plugins search` keywords and print TOON output

### DIFF
--- a/.changeset/plugins-search-or-keywords.md
+++ b/.changeset/plugins-search-or-keywords.md
@@ -2,20 +2,20 @@
 "clibuilder": minor
 ---
 
-Match `plugins search` keywords disjunctively, and print its results in TOON.
+Match `plugins search` keywords disjunctively, and add `--format` to its output.
 
 A cli declaring several keywords used to find only packages carrying *all* of them, so
 a plugin tagged with one of the cli's keywords was never listed. Each keyword is now
 searched on its own and the results are unioned, deduped, in keyword order.
 
-The output follows the Agent eXperience Interface, so an agent reading it does not have
-to parse prose:
+`plugins search --format <toon|text|json>` picks how that result is rendered. The default
+is `toon`, following the Agent eXperience Interface — a cli's plugin search is read by an
+agent far more often than by a person, and toon is the cheaper read for one:
 
 ```
 packages[2]: pkg-x,pkg-y
 help[1]: Run `plugins list` to see which of them are installed
 ```
 
-An empty result is stated explicitly as `packages: 0 packages found with keywords: a, b`.
-The previous `found one package: x` / `found the following packages:` wording is gone —
-anything scripted against those strings needs updating.
+`--format text` is the previous human-readable prose, unchanged. `--format json` emits
+`{ "packages": [...] }` alone, with no help line, so it survives a pipe into `jq`.

--- a/.changeset/plugins-search-or-keywords.md
+++ b/.changeset/plugins-search-or-keywords.md
@@ -19,3 +19,15 @@ help[1]: Run `plugins list` to see which of them are installed
 
 `--format text` is the previous human-readable prose, unchanged. `--format json` emits
 `{ "packages": [...] }` alone, with no help line, so it survives a pipe into `jq`.
+
+`--fields keywords` adds which of the cli's keywords found each package — the question
+disjunctive matching makes worth asking, since one over-broad keyword can now pull in a
+package that is not a plugin at all. It is off by default: a cli with a single keyword
+would spend the column on a value every row repeats.
+
+```
+packages[3]{name,keywords}:
+  my-cli-plugin-alpha,my-cli-plugin
+  shared-plugin,my-cli-plugin unional
+  unional-tool,unional
+```

--- a/.changeset/plugins-search-or-keywords.md
+++ b/.changeset/plugins-search-or-keywords.md
@@ -1,0 +1,21 @@
+---
+"clibuilder": minor
+---
+
+Match `plugins search` keywords disjunctively, and print its results in TOON.
+
+A cli declaring several keywords used to find only packages carrying *all* of them, so
+a plugin tagged with one of the cli's keywords was never listed. Each keyword is now
+searched on its own and the results are unioned, deduped, in keyword order.
+
+The output follows the Agent eXperience Interface, so an agent reading it does not have
+to parse prose:
+
+```
+packages[2]: pkg-x,pkg-y
+help[1]: Run `plugins list` to see which of them are installed
+```
+
+An empty result is stated explicitly as `packages: 0 packages found with keywords: a, b`.
+The previous `found one package: x` / `found the following packages:` wording is gone —
+anything scripted against those strings needs updating.

--- a/packages/clibuilder/ts/commands.spec.ts
+++ b/packages/clibuilder/ts/commands.spec.ts
@@ -146,6 +146,72 @@ describe('searchPluginsCommand', () => {
 		expect(ctx.sl.reporter.getLogMessage()).toContain('packages[3]: pkg-a,pkg-shared,pkg-b')
 	})
 
+	test('--format text keeps the human-readable prose', async () => {
+		const ctx = mockContext()
+		await builder(ctx, { name: 'plugin-cli', version: '1.0.0', keywords: ['plugin-cli-plugin'] })
+			.command({
+				...searchPluginsCommand,
+				context: { searchByKeywords: (_: string[]) => Promise.resolve(['pkg-x', 'pkg-y']) }
+			})
+			.parse(argv('string-bin search --format text'))
+
+		expect(ctx.sl.reporter.getLogMessage()).toContain(`found the following packages:
+
+  pkg-x
+  pkg-y`)
+	})
+
+	test('--format text reports one package and none in prose', async () => {
+		const one = mockContext()
+		await builder(one, { name: 'plugin-cli', version: '1.0.0', keywords: ['plugin-cli-plugin'] })
+			.command({
+				...searchPluginsCommand,
+				context: { searchByKeywords: (_: string[]) => Promise.resolve(['pkg-x']) }
+			})
+			.parse(argv('string-bin search --format text'))
+		expect(one.sl.reporter.getLogMessage()).toContain('found one package: pkg-x')
+
+		const none = mockContext()
+		await builder(none, { name: 'plugin-cli', version: '1.0.0', keywords: ['plugin-cli-plugin'] })
+			.command({
+				...searchPluginsCommand,
+				context: { searchByKeywords: () => Promise.resolve([]) }
+			})
+			.parse(argv('string-bin search --format text'))
+		expect(none.sl.reporter.getLogMessage()).toContain('no package with keywords: plugin-cli-plugin')
+	})
+
+	test('--format json emits the payload alone, so it survives a pipe', async () => {
+		const ctx = mockContext()
+		await builder(ctx, { name: 'plugin-cli', version: '1.0.0', keywords: ['plugin-cli-plugin'] })
+			.command({
+				...searchPluginsCommand,
+				context: { searchByKeywords: (_: string[]) => Promise.resolve(['pkg-x', 'pkg-y']) }
+			})
+			.parse(argv('string-bin search --format json'))
+
+		const msg = ctx.sl.reporter.getLogMessage()
+		expect(msg).toContain(`{
+  "packages": [
+    "pkg-x",
+    "pkg-y"
+  ]
+}`)
+		expect(msg).not.toContain('help[1]')
+	})
+
+	test('--format json states the empty result as data', async () => {
+		const ctx = mockContext()
+		await builder(ctx, { name: 'plugin-cli', version: '1.0.0', keywords: ['plugin-cli-plugin'] })
+			.command({
+				...searchPluginsCommand,
+				context: { searchByKeywords: () => Promise.resolve([]) }
+			})
+			.parse(argv('string-bin search --format json'))
+
+		expect(ctx.sl.reporter.getLogMessage()).toContain('"packages": []')
+	})
+
 	test('reports zero with every keyword when no keyword matches', async () => {
 		const ctx = mockContext()
 		await builder(ctx, { name: 'plugin-cli', version: '1.0.0', keywords: ['keyword-a', 'keyword-b'] })

--- a/packages/clibuilder/ts/commands.spec.ts
+++ b/packages/clibuilder/ts/commands.spec.ts
@@ -59,7 +59,7 @@ describe('searchPluginsCommand', () => {
 			})
 			.parse(argv('string-bin search'))
 
-		expect(ctx.sl.reporter.getLogMessage()).toContain('no package with keywords: plugin-cli-plugin')
+		expect(ctx.sl.reporter.getLogMessage()).toContain('packages: 0 packages found with keywords: plugin-cli-plugin')
 	})
 
 	test('one plugin', async () => {
@@ -71,7 +71,7 @@ describe('searchPluginsCommand', () => {
 			})
 			.parse(argv('string-bin search'))
 
-		expect(ctx.sl.reporter.getLogMessage()).toContain('found one package: pkg-x')
+		expect(ctx.sl.reporter.getLogMessage()).toContain('packages[1]: pkg-x')
 	})
 
 	test('two plugins', async () => {
@@ -83,9 +83,65 @@ describe('searchPluginsCommand', () => {
 			})
 			.parse(argv('string-bin search'))
 
-		expect(ctx.sl.reporter.getLogMessage()).toContain(`found the following packages:
+		expect(ctx.sl.reporter.getLogMessage()).toContain('packages[2]: pkg-x,pkg-y')
+	})
 
-  pkg-x
-  pkg-y`)
+	test('suggests the next command when packages are found', async () => {
+		const ctx = mockContext()
+		await builder(ctx, { name: 'plugin-cli', version: '1.0.0', keywords: ['plugin-cli-plugin'] })
+			.command({
+				...searchPluginsCommand,
+				context: { searchByKeywords: (_: string[]) => Promise.resolve(['pkg-x']) }
+			})
+			.parse(argv('string-bin search'))
+
+		expect(ctx.sl.reporter.getLogMessage()).toContain('help[1]: Run `plugins list` to see which of them are installed')
+	})
+
+	test('quotes package names containing the toon delimiter', async () => {
+		const ctx = mockContext()
+		await builder(ctx, { name: 'plugin-cli', version: '1.0.0', keywords: ['plugin-cli-plugin'] })
+			.command({
+				...searchPluginsCommand,
+				context: { searchByKeywords: (_: string[]) => Promise.resolve(['@scope/pkg-x', 'odd,name']) }
+			})
+			.parse(argv('string-bin search'))
+
+		expect(ctx.sl.reporter.getLogMessage()).toContain('packages[2]: @scope/pkg-x,"odd,name"')
+	})
+
+	test('searches each keyword separately and unions the results', async () => {
+		const ctx = mockContext()
+		const calls: string[][] = []
+		const found: Record<string, string[]> = {
+			'keyword-a': ['pkg-a', 'pkg-shared'],
+			'keyword-b': ['pkg-shared', 'pkg-b']
+		}
+		await builder(ctx, { name: 'plugin-cli', version: '1.0.0', keywords: ['keyword-a', 'keyword-b'] })
+			.command({
+				...searchPluginsCommand,
+				context: {
+					searchByKeywords: (keywords: string[]) => {
+						calls.push(keywords)
+						return Promise.resolve(keywords.flatMap((k) => found[k] ?? []))
+					}
+				}
+			})
+			.parse(argv('string-bin search'))
+
+		expect(calls).toEqual([['keyword-a'], ['keyword-b']])
+		expect(ctx.sl.reporter.getLogMessage()).toContain('packages[3]: pkg-a,pkg-shared,pkg-b')
+	})
+
+	test('reports zero with every keyword when no keyword matches', async () => {
+		const ctx = mockContext()
+		await builder(ctx, { name: 'plugin-cli', version: '1.0.0', keywords: ['keyword-a', 'keyword-b'] })
+			.command({
+				...searchPluginsCommand,
+				context: { searchByKeywords: (_: string[]) => Promise.resolve([]) }
+			})
+			.parse(argv('string-bin search'))
+
+		expect(ctx.sl.reporter.getLogMessage()).toContain('packages: 0 packages found with keywords: keyword-a, keyword-b')
 	})
 })

--- a/packages/clibuilder/ts/commands.spec.ts
+++ b/packages/clibuilder/ts/commands.spec.ts
@@ -110,6 +110,19 @@ describe('searchPluginsCommand', () => {
 		expect(ctx.sl.reporter.getLogMessage()).toContain('packages[2]: @scope/pkg-x,"odd,name"')
 	})
 
+	test('escapes quotes and backslashes in package names', async () => {
+		const ctx = mockContext()
+		await builder(ctx, { name: 'plugin-cli', version: '1.0.0', keywords: ['plugin-cli-plugin'] })
+			.command({
+				...searchPluginsCommand,
+				context: { searchByKeywords: (_: string[]) => Promise.resolve(['odd"name', 'trailing\\']) }
+			})
+			.parse(argv('string-bin search'))
+
+		// a hand-escaped trailing backslash would escape the closing quote and merge the entries
+		expect(ctx.sl.reporter.getLogMessage()).toContain('packages[2]: "odd\\"name","trailing\\\\"')
+	})
+
 	test('searches each keyword separately and unions the results', async () => {
 		const ctx = mockContext()
 		const calls: string[][] = []

--- a/packages/clibuilder/ts/commands.spec.ts
+++ b/packages/clibuilder/ts/commands.spec.ts
@@ -212,6 +212,62 @@ describe('searchPluginsCommand', () => {
 		expect(ctx.sl.reporter.getLogMessage()).toContain('"packages": []')
 	})
 
+	describe('--fields keywords', () => {
+		// `pkg-a` matches only the first keyword, `pkg-b` only the second, `pkg-both` carries both.
+		const mixed: Record<string, string[]> = {
+			'keyword-a': ['pkg-a', 'pkg-both'],
+			'keyword-b': ['pkg-both', 'pkg-b']
+		}
+		const searchMixed = (keywords: string[]) => Promise.resolve(keywords.flatMap((k) => mixed[k] ?? []))
+
+		async function search(ctx: ReturnType<typeof mockContext>, line: string) {
+			await builder(ctx, { name: 'plugin-cli', version: '1.0.0', keywords: ['keyword-a', 'keyword-b'] })
+				.command({ ...searchPluginsCommand, context: { searchByKeywords: searchMixed } })
+				.parse(argv(line))
+			return ctx.sl.reporter.getLogMessage()
+		}
+
+		test('reports which keyword found each package as a toon table', async () => {
+			expect(await search(mockContext(), 'string-bin search --fields keywords')).toContain(`packages[3]{name,keywords}:
+  pkg-a,keyword-a
+  pkg-both,keyword-a keyword-b
+  pkg-b,keyword-b`)
+		})
+
+		test('naming `name` alongside it is a no-op, not an error', async () => {
+			expect(await search(mockContext(), 'string-bin search --fields name,keywords')).toContain(
+				'packages[3]{name,keywords}:'
+			)
+		})
+
+		test('stays a flat array when the field is not asked for', async () => {
+			expect(await search(mockContext(), 'string-bin search')).toContain('packages[3]: pkg-a,pkg-both,pkg-b')
+		})
+
+		test('annotates the prose in --format text', async () => {
+			expect(await search(mockContext(), 'string-bin search --format text --fields keywords')).toContain(`  pkg-a (keyword-a)
+  pkg-both (keyword-a, keyword-b)
+  pkg-b (keyword-b)`)
+		})
+
+		test('turns the json payload into objects', async () => {
+			expect(await search(mockContext(), 'string-bin search --format json --fields keywords')).toContain(`{
+      "name": "pkg-both",
+      "keywords": [
+        "keyword-a",
+        "keyword-b"
+      ]
+    }`)
+		})
+
+		test('rejects an unknown field instead of silently dropping it', async () => {
+			const msg = await search(mockContext(), 'string-bin search --fields author')
+			expect(msg).toContain('error: unknown value for --fields: author')
+			expect(msg).toContain('help[1]: The only extra field is `keywords`')
+			expect(msg).not.toContain('packages[')
+		})
+	})
+
 	test('reports zero with every keyword when no keyword matches', async () => {
 		const ctx = mockContext()
 		await builder(ctx, { name: 'plugin-cli', version: '1.0.0', keywords: ['keyword-a', 'keyword-b'] })

--- a/packages/clibuilder/ts/commands.ts
+++ b/packages/clibuilder/ts/commands.ts
@@ -111,11 +111,14 @@ export const searchPluginsCommand = command({
 /**
  * Quotes a toon value when it would otherwise be ambiguous.
  *
- * Package names have no reason to contain a comma or a quote, but the registry is not
- * ours to trust: an unquoted one would read as two entries to whoever parses the output.
+ * Package names have no reason to contain a comma, a quote, or a backslash, but the
+ * registry is not ours to trust: an unquoted one would read as two entries to whoever
+ * parses the output. `JSON.stringify` does the escaping, since toon strings escape the
+ * same way json ones do — hand-rolling it drops the backslash case, which is worse than
+ * not quoting at all (a trailing `\` would escape the closing quote).
  */
 function toonValue(value: string) {
-	return /[",]/.test(value) ? `"${value.replace(/"/g, '\\"')}"` : value
+	return /["\\,]|^\s|\s$/.test(value) ? JSON.stringify(value) : value
 }
 
 export const pluginsCommand = command({

--- a/packages/clibuilder/ts/commands.ts
+++ b/packages/clibuilder/ts/commands.ts
@@ -94,20 +94,29 @@ export const searchPluginsCommand = command({
 	description: 'Search only for available plugins',
 	context: { searchByKeywords },
 	async run() {
-		const packages = await this.context.searchByKeywords(this.keywords)
+		// `searchByKeywords` matches packages carrying *all* of the keywords it is given.
+		// A cli declaring several keywords wants a package matching *any* of them, so query
+		// one keyword at a time and union the results, first-seen order wins.
+		const found = await Promise.all(this.keywords.map((keyword) => this.context.searchByKeywords([keyword])))
+		const packages = [...new Set(found.flat())]
 		if (packages.length === 0) {
-			this.ui.info(`no package with keywords: ${this.keywords.join(', ')}`)
-		} else if (packages.length === 1) {
-			this.ui.info(`found one package: ${packages[0]}`)
-		} else {
-			this.ui.info('found the following packages:')
-			this.ui.info('')
-			packages.forEach((p) => {
-				this.ui.info(`  ${p}`)
-			})
+			this.ui.info(`packages: 0 packages found with keywords: ${this.keywords.join(', ')}`)
+			return
 		}
+		this.ui.info(`packages[${packages.length}]: ${packages.map(toonValue).join(',')}`)
+		this.ui.info('help[1]: Run `plugins list` to see which of them are installed')
 	}
 })
+
+/**
+ * Quotes a toon value when it would otherwise be ambiguous.
+ *
+ * Package names have no reason to contain a comma or a quote, but the registry is not
+ * ours to trust: an unquoted one would read as two entries to whoever parses the output.
+ */
+function toonValue(value: string) {
+	return /[",]/.test(value) ? `"${value.replace(/"/g, '\\"')}"` : value
+}
 
 export const pluginsCommand = command({
 	name: 'plugins',

--- a/packages/clibuilder/ts/commands.ts
+++ b/packages/clibuilder/ts/commands.ts
@@ -97,18 +97,58 @@ export const searchPluginsCommand = command({
 			type: z.optional(z.enum(['toon', 'text', 'json'])),
 			description: "Output format: 'toon' for agents, 'text' for humans, 'json' to pipe",
 			default: 'toon' as const
+		},
+		fields: {
+			type: z.optional(z.string()),
+			description: "Extra fields to report, comma separated. Only 'keywords' is available"
 		}
 	},
 	context: { searchByKeywords },
 	async run(args) {
+		const fields = parseFields(args.fields)
+		if (!fields) {
+			this.ui.info(`error: unknown value for --fields: ${args.fields}`)
+			this.ui.info('help[1]: The only extra field is `keywords`. Run `plugins search --fields keywords`')
+			return
+		}
 		// `searchByKeywords` matches packages carrying *all* of the keywords it is given.
 		// A cli declaring several keywords wants a package matching *any* of them, so query
 		// one keyword at a time and union the results, first-seen order wins.
 		const found = await Promise.all(this.keywords.map((keyword) => this.context.searchByKeywords([keyword])))
-		const packages = [...new Set(found.flat())]
-		reportPackages(this.ui, args.format, packages, this.keywords)
+		// a `Map` keyed by name is the union and the provenance in one pass: insertion order is
+		// first-seen order, and a package matched by a later keyword appends rather than repeats.
+		const packages = new Map<string, string[]>()
+		found.forEach((names, i) => {
+			names.forEach((name) => {
+				const matched = packages.get(name)
+				if (matched) matched.push(this.keywords[i]!)
+				else packages.set(name, [this.keywords[i]!])
+			})
+		})
+		reportPackages(this.ui, args.format, fields, [...packages].map(toPackage), this.keywords)
 	}
 })
+
+type FoundPackage = { name: string; keywords: string[] }
+
+function toPackage([name, keywords]: [string, string[]]): FoundPackage {
+	return { name, keywords }
+}
+
+/**
+ * Reads `--fields` into the set of extra columns to report.
+ *
+ * `name` is not one of them: it is the row's identity, so it is always present and
+ * naming it is accepted as a no-op rather than rejected. Returns `undefined` for an
+ * unrecognized field, which the caller reports — silently dropping it would hand back a
+ * narrower result than was asked for, which AXI treats as worse than an error.
+ */
+function parseFields(fields: string | undefined) {
+	if (fields === undefined) return { keywords: false }
+	const requested = fields.split(',').map((f) => f.trim())
+	if (requested.some((f) => f !== 'keywords' && f !== 'name')) return undefined
+	return { keywords: requested.includes('keywords') }
+}
 
 /**
  * Renders the search result in the caller's chosen format.
@@ -120,12 +160,14 @@ export const searchPluginsCommand = command({
 function reportPackages(
 	ui: { info(...args: any[]): void },
 	format: 'toon' | 'text' | 'json' | undefined,
-	packages: string[],
+	fields: { keywords: boolean },
+	packages: FoundPackage[],
 	keywords: string[]
 ) {
 	if (format === 'json') {
 		// no help line here — a `| jq` consumer wants the payload and nothing else.
-		ui.info(JSON.stringify({ packages }, undefined, 2))
+		const payload = fields.keywords ? packages : packages.map((p) => p.name)
+		ui.info(JSON.stringify({ packages: payload }, undefined, 2))
 		return
 	}
 	if (format === 'text') {
@@ -133,14 +175,15 @@ function reportPackages(
 			ui.info(`no package with keywords: ${keywords.join(', ')}`)
 			return
 		}
+		const describe = (p: FoundPackage) => (fields.keywords ? `${p.name} (${p.keywords.join(', ')})` : p.name)
 		if (packages.length === 1) {
-			ui.info(`found one package: ${packages[0]}`)
+			ui.info(`found one package: ${describe(packages[0]!)}`)
 			return
 		}
 		ui.info('found the following packages:')
 		ui.info('')
 		packages.forEach((p) => {
-			ui.info(`  ${p}`)
+			ui.info(`  ${describe(p)}`)
 		})
 		return
 	}
@@ -148,7 +191,16 @@ function reportPackages(
 		ui.info(`packages: 0 packages found with keywords: ${keywords.join(', ')}`)
 		return
 	}
-	ui.info(`packages[${packages.length}]: ${packages.map(toonValue).join(',')}`)
+	if (fields.keywords) {
+		// tabular toon: the extra column is worth a row per package, where the flat form is not.
+		// the cell joins on a space because comma is the field delimiter.
+		ui.info(`packages[${packages.length}]{name,keywords}:`)
+		packages.forEach((p) => {
+			ui.info(`  ${toonValue(p.name)},${toonValue(p.keywords.join(' '))}`)
+		})
+	} else {
+		ui.info(`packages[${packages.length}]: ${packages.map((p) => toonValue(p.name)).join(',')}`)
+	}
 	ui.info('help[1]: Run `plugins list` to see which of them are installed')
 }
 

--- a/packages/clibuilder/ts/commands.ts
+++ b/packages/clibuilder/ts/commands.ts
@@ -92,21 +92,65 @@ export const listPluginsCommand = command({
 export const searchPluginsCommand = command({
 	name: 'search',
 	description: 'Search only for available plugins',
+	options: {
+		format: {
+			type: z.optional(z.enum(['toon', 'text', 'json'])),
+			description: "Output format: 'toon' for agents, 'text' for humans, 'json' to pipe",
+			default: 'toon' as const
+		}
+	},
 	context: { searchByKeywords },
-	async run() {
+	async run(args) {
 		// `searchByKeywords` matches packages carrying *all* of the keywords it is given.
 		// A cli declaring several keywords wants a package matching *any* of them, so query
 		// one keyword at a time and union the results, first-seen order wins.
 		const found = await Promise.all(this.keywords.map((keyword) => this.context.searchByKeywords([keyword])))
 		const packages = [...new Set(found.flat())]
-		if (packages.length === 0) {
-			this.ui.info(`packages: 0 packages found with keywords: ${this.keywords.join(', ')}`)
-			return
-		}
-		this.ui.info(`packages[${packages.length}]: ${packages.map(toonValue).join(',')}`)
-		this.ui.info('help[1]: Run `plugins list` to see which of them are installed')
+		reportPackages(this.ui, args.format, packages, this.keywords)
 	}
 })
+
+/**
+ * Renders the search result in the caller's chosen format.
+ *
+ * `toon` is the default because a cli's plugin search is read by an agent far more often
+ * than by a person, and toon is the cheaper read for one. It is a default, not the only
+ * option: `text` is the prose a human wants, and `json` is what survives a pipe.
+ */
+function reportPackages(
+	ui: { info(...args: any[]): void },
+	format: 'toon' | 'text' | 'json' | undefined,
+	packages: string[],
+	keywords: string[]
+) {
+	if (format === 'json') {
+		// no help line here — a `| jq` consumer wants the payload and nothing else.
+		ui.info(JSON.stringify({ packages }, undefined, 2))
+		return
+	}
+	if (format === 'text') {
+		if (packages.length === 0) {
+			ui.info(`no package with keywords: ${keywords.join(', ')}`)
+			return
+		}
+		if (packages.length === 1) {
+			ui.info(`found one package: ${packages[0]}`)
+			return
+		}
+		ui.info('found the following packages:')
+		ui.info('')
+		packages.forEach((p) => {
+			ui.info(`  ${p}`)
+		})
+		return
+	}
+	if (packages.length === 0) {
+		ui.info(`packages: 0 packages found with keywords: ${keywords.join(', ')}`)
+		return
+	}
+	ui.info(`packages[${packages.length}]: ${packages.map(toonValue).join(',')}`)
+	ui.info('help[1]: Run `plugins list` to see which of them are installed')
+}
 
 /**
  * Quotes a toon value when it would otherwise be ambiguous.


### PR DESCRIPTION
## What

Two changes to `plugins search`:

**1. OR keyword matching.** `search-packages`' `searchByKeywords` matches packages carrying *all* of the keywords it is given (`hasAllKeywords`), so a cli declaring several keywords never listed a plugin tagged with only one of them. The command now queries one keyword at a time and unions the results, deduped, first-seen order (keyword order, then registry order within a keyword).

The fix landed in `clibuilder` rather than upstream: `search-packages` is a separate published repo, and its all-keywords contract is documented and intentional — the union is this caller's concern.

**2. AXI output, behind `--format`.** The default is `toon`, following the Agent eXperience Interface — a cli's plugin search is read by an agent far more often than by a person:

```
packages[2]: pkg-x,pkg-y
help[1]: Run `plugins list` to see which of them are installed

packages: 0 packages found with keywords: keyword-a, keyword-b
```

It is a default, not the only option. `--format text` is the previous human-readable prose, unchanged. `--format json` emits `{ "packages": [...] }` alone — no help line — so it survives a pipe into `jq`. This follows the option shape cyber-mux uses (`output(data, readable)`): a structured default with an explicit escape, never structured-only.

Names are quoted (via `JSON.stringify`, so backslashes escape too) when they contain a comma, quote, backslash, or edge whitespace, so a hostile package name cannot read as two entries.

**`--fields keywords`** reports which of the cli's keywords found each package:

```
packages[3]{name,keywords}:
  my-cli-plugin-alpha,my-cli-plugin
  shared-plugin,my-cli-plugin unional
  unional-tool,unional
```

Disjunctive matching is what makes that worth asking — one over-broad keyword (an author name, say) now pulls in packages that are not plugins for this cli at all, and the column names the keyword to drop. It is off by default: a field earns its slot by discriminating, and a cli with a single keyword (the common case, since `keywords` defaults to the cli name) would spend the column on a value every row repeats. An unknown field is refused by name rather than dropped.

## Not in scope

`plugins list` has the same all-keywords semantics via `find-installed-packages`. Left alone deliberately — reported, not silently widened.

An AXI audit of the rest of the surface turned up a larger gap that belongs in its own PR: `lookupCommand` produces typed errors for unknown flags, missing arguments and bad values, and `builder.ts` discards the array, prints full help, and exits 0. `context.exit` is wired but never called anywhere, so nothing this library does can exit non-zero — which is also why the `--fields` error above exits 0 where AXI wants 2.

## Verification

`pnpm verify` green (lint, build, coverage, depcheck, size). `commands.ts` is at 100% coverage; tests cover the multi-keyword union, dedup, per-keyword fan-out, delimiter and backslash quoting, all three formats, `--fields` in each of them, the unknown-field refusal, and the zero/one/many shapes. Changeset included (`minor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)