### PR TITLE
feat(clibuilder): report usage errors and exit non-zero

### DIFF
--- a/.changeset/heavy-donkeys-repeat.md
+++ b/.changeset/heavy-donkeys-repeat.md
@@ -1,0 +1,29 @@
+---
+'clibuilder': minor
+---
+
+Report usage errors and exit non-zero.
+
+A clibuilder cli could not fail. `lookupCommand` already built a typed list of everything wrong with
+an invocation — unknown option, missing argument, extra arguments, a value of the wrong type — and
+`builder` threw it away and printed the help message with an exit code of `0`. A command that knew
+it had failed had no way to say so either.
+
+- Usage errors are now reported by name (`unknown option --bogus`, `missing required argument
+  <target>`) ahead of the help message, and the cli exits `2`.
+- A config that fails its schema exits `1`.
+- A command fails by throwing the new `CliError`, which carries an `exitCode` and optional `help`
+  lines. `parse()` still resolves rather than rejecting, so the failure is reported instead of
+  surfacing as an unhandled rejection.
+- New exports: `CliError`, `exitCodes` (`success`/`error`/`usage` — 0/1/2), and `isCliError()`.
+- `testCommand()` returns the `exitCode` alongside `result` and `messages`, so a test can assert a
+  failure without ending the test run.
+- `--help` and `--version` are accepted by every command, including sub-commands that declare no
+  options of their own, and both still exit `0`.
+
+The exit code is recorded on `process.exitCode` rather than applied with `process.exit()`, so
+pending stdout writes are not truncated.
+
+**This changes the behavior of every cli built with clibuilder**: an invocation with a typo used to
+exit `0` and now exits `2`. The TypeScript surface is additive, which is why this is a minor rather
+than a major, but a caller downstream of your cli that ignored the exit code will now see it fail.

--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -45,6 +45,7 @@ export default defineConfig({
 						{ label: 'Arguments & Options', slug: 'guides/arguments-and-options' },
 						{ label: 'Configuration', slug: 'guides/configuration' },
 						{ label: 'Plugins', slug: 'guides/plugins' },
+						{ label: 'Failing', slug: 'guides/failing' },
 						{ label: 'Testing', slug: 'guides/testing' },
 						{ label: 'Publishing', slug: 'guides/publishing' }
 					]

--- a/apps/website/src/content/docs/api/index.md
+++ b/apps/website/src/content/docs/api/index.md
@@ -19,12 +19,15 @@ import { cli, command, testCommand, parseArgv, z } from 'clibuilder'
 | `defineKey()` / `defineCollectionKey()` | Create typed plugin registry keys |
 | [`parseArgv()`](/clibuilder/api/parse-argv/) | The raw argv tokenizer, exported for reuse |
 | [`enableCompileCache()`](/clibuilder/api/compile-cache/) | Opt into Node's V8 compile cache, from `clibuilder/compile-cache` |
+| `isCliError()` | Whether a caught value is a [`CliError`](/clibuilder/guides/failing/) |
 
 ## Values
 
 | Export | Purpose |
 | --- | --- |
 | [`z`](/clibuilder/api/zod/) | The zod instance used for every schema in the library |
+| [`exitCodes`](/clibuilder/guides/failing/#exit-codes) | The codes the cli exits with — `success`, `error`, `usage` |
+| [`CliError`](/clibuilder/guides/failing/#failing-from-a-command) | Thrown from `run()` to fail the cli with a message and an exit code |
 
 ## Types
 

--- a/apps/website/src/content/docs/api/test-command.md
+++ b/apps/website/src/content/docs/api/test-command.md
@@ -8,7 +8,7 @@ function testCommand(
   command: cli.Command,
   argv: string,
   config?: Record<string, any>
-): Promise<{ result: any; messages: string }>
+): Promise<{ result: any; messages: string; exitCode: number | undefined }>
 ```
 
 Runs a single command against a throwaway CLI (`test-cli`, version `1.0.0`) and returns what it did.
@@ -47,6 +47,7 @@ expect(messages).toBe('miku')
 | --- | --- | --- |
 | `result` | `any` | What `run()` returned or resolved to. |
 | `messages` | `string` | Everything written through `this.ui` — `info`, `warn`, and `error` — joined with `\n`. Empty when nothing was printed. |
+| `exitCode` | `number \| undefined` | The code the cli would have exited with, or `undefined` when it did not fail. |
 
 The display level is `info`, so `this.ui.debug()` output does **not** appear in `messages` unless the
 `argv` you pass includes `--verbose`.
@@ -84,18 +85,22 @@ const { result } = await testCommand(
 expect(result).toEqual({ a: 'hi' })
 ```
 
-Passing a config that fails the schema is how you test the failure path — `result` is `undefined` and
-`messages` carries the validation errors and the help message.
+Passing a config that fails the schema is how you test the failure path — `result` is `undefined`,
+`exitCode` is `1`, and `messages` carries the validation errors and the help message.
 
 ## Asserting on failures
 
-Usage errors don't reject; they print help. So assert on `messages`:
+Failures don't reject — they are reported and recorded. Assert on `exitCode` and `messages`:
 
 ```ts
-const { result, messages } = await testCommand(cmd, 'cmd --unknown-flag')
+const { result, messages, exitCode } = await testCommand(cmd, 'cmd --unknown-flag')
 expect(result).toBeUndefined()
-expect(messages).toContain('Usage:')
+expect(exitCode).toBe(2)
+expect(messages).toContain('unknown option --unknown-flag')
 ```
+
+A command that throws [`CliError`](/clibuilder/guides/failing/) is recorded the same way, with the
+code it chose.
 
 See [Testing](/clibuilder/guides/testing/) for the wider picture, including injecting fakes through a
 command's `context`.

--- a/apps/website/src/content/docs/guides/failing.md
+++ b/apps/website/src/content/docs/guides/failing.md
@@ -1,0 +1,121 @@
+---
+title: Failing
+description: Exit codes, usage errors, and how a command reports that it could not do what was asked.
+---
+
+A cli that always exits `0` is a cli whose caller — a shell script, a CI job, an agent — cannot tell
+whether it worked. clibuilder reports failures two ways: it rejects invocations it cannot make sense
+of, and it gives your command a way to say it failed.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | The command did what was asked, including no-ops. |
+| `1` | The command was called correctly but could not complete. |
+| `2` | The command was called incorrectly — an unknown option, a missing argument, a value of the wrong type. |
+
+The codes are exported as `exitCodes` so you do not have to remember the numbers:
+
+```ts
+import { exitCodes } from 'clibuilder'
+
+exitCodes.success // 0
+exitCodes.error   // 1
+exitCodes.usage   // 2
+```
+
+This is the convention a caller driving your cli through a shell expects: `2` means *do not retry
+this invocation, it is malformed*, while `1` means *the invocation was fine, the world was not*.
+
+clibuilder sets `process.exitCode` rather than calling `process.exit()`, so pending writes to stdout
+are never truncated — node exits with the recorded code once your cli is done.
+
+## Usage errors
+
+Anything the parser cannot reconcile with the command's `arguments` and `options` is reported by
+name, followed by the command's help message, and the cli exits `2`:
+
+```sh
+$ my-cli deploy --dyr-run
+unknown option --dyr-run
+
+Usage: my-cli deploy <arguments> [options]
+...
+```
+
+Every problem found is reported, not just the first:
+
+```sh
+$ my-cli deploy --bogus
+unknown option --bogus
+missing required argument <target>
+```
+
+The global options — `--help`, `--version`, `--verbose`, `--silent`, `--debug-cli` and
+`--show-config` — are accepted by every command, so they are never reported as unknown. `--help` and
+`--version` are answered even when the rest of the command line is invalid, and both exit `0`:
+asking for help is not a usage error.
+
+## Failing from a command
+
+Throw `CliError` from `run()`. clibuilder prints the message through the command's `ui`, prints the
+help lines after it, and exits with the code you chose. `parse()` resolves to `undefined` instead of
+rejecting, so the failure is reported to the user rather than surfacing as an unhandled rejection
+with a stack trace.
+
+```ts
+import { CliError, command, exitCodes, z } from 'clibuilder'
+
+const fields = ['name', 'version', 'description']
+
+export const view = command({
+  name: 'view',
+  description: 'show a package',
+  options: { fields: { description: 'fields to show', type: z.optional(z.array(z.string())) } },
+  async run(args) {
+    const unknown = (args.fields ?? []).filter((f) => !fields.includes(f))
+    if (unknown.length > 0) {
+      throw new CliError(`unknown field: ${unknown.join(', ')}`, {
+        exitCode: exitCodes.usage,
+        help: `valid fields: ${fields.join(', ')}`
+      })
+    }
+    // ...
+  }
+})
+```
+
+`CliError` takes:
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `exitCode` | `number` | The code the cli exits with. Defaults to `exitCodes.error` (1). |
+| `help` | `string \| string[]` | What the caller should do about it. Printed after the message, one line each. |
+| `cause` | `unknown` | The underlying error, kept for the caller to inspect. |
+
+Use `exitCodes.usage` when the invocation itself was wrong — a value your schema could not have
+caught, such as an option value that is only valid for certain other values. Use the default for
+everything else: a network call that failed, a file that was not there, a build that did not
+succeed.
+
+Any other error thrown from `run()` is a defect rather than a reported failure, so it keeps
+propagating out of `parse()` untouched.
+
+## Asserting on failures in tests
+
+`testCommand()` reports the exit code alongside the result and the messages, and no process is
+harmed:
+
+```ts
+import { testCommand } from 'clibuilder'
+
+test('view rejects an unknown field', async () => {
+  const { exitCode, messages } = await testCommand(view, 'view --fields bogus')
+
+  expect(exitCode).toBe(2)
+  expect(messages).toContain('unknown field: bogus')
+})
+```
+
+`exitCode` is `undefined` when the command did not fail — the same as a process that exits `0`.

--- a/apps/website/src/content/docs/guides/testing.md
+++ b/apps/website/src/content/docs/guides/testing.md
@@ -30,6 +30,8 @@ test('cmd-a returns x and says miku', async () => {
 ```
 
 - **`result`** is whatever `run()` returned or resolved to.
+- **`exitCode`** is the code the cli would have exited with, or `undefined` when the command did not
+  fail — see [Failing](/clibuilder/guides/failing/).
 - **`messages`** is everything the command wrote through `this.ui`, joined with newlines — `info`,
   `warn`, and `error` all land here, so a test can assert on user-facing output without capturing
   stdout.

--- a/packages/clibuilder/ts/builder.spec.ts
+++ b/packages/clibuilder/ts/builder.spec.ts
@@ -2,7 +2,7 @@ import { a } from 'assertron'
 import { assertType, type IsExtend, required, testType } from 'type-plus'
 import { builder } from './builder.js'
 import { mockContext } from './context.mock.js'
-import { type cli, command, z } from './index.js'
+import { CliError, type cli, command, exitCodes, z } from './index.js'
 import { argv, getFixturePath } from './test-utils/index.js'
 
 function setupBuilderTest(contextParams?: mockContext.Params, options?: Partial<cli.Options>) {
@@ -129,7 +129,7 @@ describe('help', () => {
 		const [builder, ctx] = setupBuilderTest()
 		const cli = builder.default({ run() {} })
 		await cli.parse(argv('test-cli not-exist'))
-		expect(ctx.sl.reporter.getLogMessage()).toEqual(getHelpMessage(cli))
+		expect(ctx.sl.reporter.getLogMessage()).toContain(getHelpMessage(cli))
 	})
 	it('shows help if missing argument', async () => {
 		const [builder, ctx] = setupBuilderTest()
@@ -138,7 +138,7 @@ describe('help', () => {
 			run() {}
 		})
 		await cli.parse(argv('test-cli'))
-		expect(ctx.sl.reporter.getLogMessage()).toEqual(`
+		expect(ctx.sl.reporter.getLogMessage()).toContain(`
 Usage: test-cli <arguments> [options]
 
 Arguments:
@@ -610,6 +610,179 @@ Options:
   [--debug-cli]          Display clibuilder debug messages
 `
 }
+
+describe('usage errors', () => {
+	it('names an unknown option and exits with the usage code', async () => {
+		const [builder, ctx] = setupBuilderTest()
+		const cli = builder.default({ run() {} })
+		await cli.parse(argv('test-cli --bogus'))
+		expect(ctx.sl.reporter.getLogMessage()).toContain('unknown option --bogus')
+		expect(ctx.exitCode).toBe(2)
+	})
+	it('names a missing argument and exits with the usage code', async () => {
+		const [builder, ctx] = setupBuilderTest()
+		const cli = builder.default({
+			arguments: [{ name: 'abc', description: 'arg abc' }],
+			run() {
+				fail('should not reach')
+			}
+		})
+		await cli.parse(argv('test-cli'))
+		expect(ctx.sl.reporter.getLogMessage()).toContain('missing required argument <abc>')
+		expect(ctx.exitCode).toBe(2)
+	})
+	it('names extra arguments and exits with the usage code', async () => {
+		const [builder, ctx] = setupBuilderTest()
+		const cli = builder.default({ run() {} })
+		await cli.parse(argv('test-cli not-exist'))
+		expect(ctx.sl.reporter.getLogMessage()).toContain('unexpected argument: not-exist')
+		expect(ctx.exitCode).toBe(2)
+	})
+	it('names an invalid option value and exits with the usage code', async () => {
+		const [builder, ctx] = setupBuilderTest()
+		const cli = builder.default({
+			options: { abc: { description: 'abc', type: z.optional(z.number()) } },
+			run() {
+				fail('should not reach')
+			}
+		})
+		await cli.parse(argv('test-cli --abc=xyz'))
+		expect(ctx.sl.reporter.getLogMessage()).toContain(
+			'invalid value for option --abc: expected to be number, received "xyz"'
+		)
+		expect(ctx.exitCode).toBe(2)
+	})
+	it('names every error it found', async () => {
+		const [builder, ctx] = setupBuilderTest()
+		const cli = builder.default({
+			arguments: [{ name: 'abc', description: 'arg abc' }],
+			run() {
+				fail('should not reach')
+			}
+		})
+		await cli.parse(argv('test-cli --bogus'))
+		const msg = ctx.sl.reporter.getLogMessage()
+		expect(msg).toContain('unknown option --bogus')
+		expect(msg).toContain('missing required argument <abc>')
+	})
+	it('shows the help message after the errors', async () => {
+		const [builder, ctx] = setupBuilderTest()
+		const cli = builder.default({ run() {} })
+		await cli.parse(argv('test-cli --bogus'))
+		const msg = ctx.sl.reporter.getLogMessage()
+		expect(msg.indexOf('unknown option --bogus')).toBeLessThan(msg.indexOf('Usage: test-cli'))
+	})
+	it('does not run the command', async () => {
+		const [builder] = setupBuilderTest()
+		const cli = builder.default({
+			run() {
+				fail('should not reach')
+			}
+		})
+		expect(await cli.parse(argv('test-cli --bogus'))).toBeUndefined()
+	})
+	it('leaves the exit code alone on success', async () => {
+		const [builder, ctx] = setupBuilderTest()
+		await builder.default({ run() {} }).parse(argv('test-cli'))
+		expect(ctx.exitCode).toBeUndefined()
+	})
+	it('exits with the error code when the config fails validation', async () => {
+		const ctx = mockContext({ fixtureDir: 'has-json-config' })
+		await builder(ctx, { name: 'show-config', version: '1.0.0' })
+			.default({
+				config: z.object({ b: z.string() }),
+				run() {
+					fail('should not reach')
+				}
+			})
+			.parse(argv('show-config'))
+		expect(ctx.exitCode).toBe(1)
+	})
+})
+
+describe('global options are accepted by every command', () => {
+	it('shows help for a sub command that declares no options', async () => {
+		const [builder, ctx] = setupBuilderTest()
+		const cli = builder.command({ name: 'cmd', run: () => fail('should not reach') })
+		await cli.parse(argv('test-cli cmd -h'))
+		expect(ctx.sl.reporter.getLogMessage()).toContain('Usage: test-cli cmd')
+		expect(ctx.sl.reporter.getLogMessage()).not.toContain('unknown option')
+		expect(ctx.exitCode).toBeUndefined()
+	})
+	it('shows the version for a sub command that declares no options', async () => {
+		const [builder, ctx] = setupBuilderTest()
+		const cli = builder.command({ name: 'cmd', run: () => fail('should not reach') })
+		await cli.parse(argv('test-cli cmd --version'))
+		expect(ctx.sl.reporter.getLogMessage()).toEqual('1.0.0')
+		expect(ctx.exitCode).toBeUndefined()
+	})
+	it('shows help even when the invocation is otherwise invalid', async () => {
+		const [builder, ctx] = setupBuilderTest()
+		const cli = builder.default({
+			arguments: [{ name: 'abc', description: 'arg abc' }],
+			run: () => fail('should not reach')
+		})
+		await cli.parse(argv('test-cli --help'))
+		expect(ctx.sl.reporter.getLogMessage()).toContain('Usage: test-cli')
+		expect(ctx.exitCode).toBeUndefined()
+	})
+})
+
+describe('CliError', () => {
+	it('reports the message and exits with the error code', async () => {
+		const [builder, ctx] = setupBuilderTest()
+		const cli = builder.default({
+			run() {
+				throw new CliError('cannot reach the registry')
+			}
+		})
+		expect(await cli.parse(argv('test-cli'))).toBeUndefined()
+		expect(ctx.sl.reporter.getLogMessage()).toContain('cannot reach the registry')
+		expect(ctx.exitCode).toBe(1)
+	})
+	it('exits with the code the command chose', async () => {
+		const [builder, ctx] = setupBuilderTest()
+		const cli = builder.default({
+			run() {
+				throw new CliError('unknown field "bogus"', { exitCode: exitCodes.usage })
+			}
+		})
+		await cli.parse(argv('test-cli'))
+		expect(ctx.exitCode).toBe(2)
+	})
+	it('reports the help lines', async () => {
+		const [builder, ctx] = setupBuilderTest()
+		const cli = builder.default({
+			run() {
+				throw new CliError('unknown field "bogus"', { help: ['valid fields: name, version'] })
+			}
+		})
+		await cli.parse(argv('test-cli'))
+		expect(ctx.sl.reporter.getLogMessage()).toContain('valid fields: name, version')
+	})
+	it('is caught when thrown asynchronously', async () => {
+		const [builder, ctx] = setupBuilderTest()
+		const cli = builder.default({
+			async run() {
+				await Promise.resolve()
+				throw new CliError('async boom')
+			}
+		})
+		await cli.parse(argv('test-cli'))
+		expect(ctx.sl.reporter.getLogMessage()).toContain('async boom')
+		expect(ctx.exitCode).toBe(1)
+	})
+	it('does not swallow other errors', async () => {
+		const [builder, ctx] = setupBuilderTest()
+		const cli = builder.default({
+			run() {
+				throw new Error('boom')
+			}
+		})
+		await expect(cli.parse(argv('test-cli'))).rejects.toThrow('boom')
+		expect(ctx.exitCode).toBeUndefined()
+	})
+})
 
 describe('--show-config (#317)', () => {
 	it('prints the config and the file it was loaded from', async () => {

--- a/packages/clibuilder/ts/builder.ts
+++ b/packages/clibuilder/ts/builder.ts
@@ -5,7 +5,8 @@ import type { Command } from './command.internal.types.js'
 import { getBaseCommand, pluginsCommand } from './commands.js'
 import { describeConfigSource } from './config.js'
 import type { Context } from './context.js'
-import { lookupCommand } from './lookup_command.js'
+import { exitCodes, formatLookupError, isCliError } from './errors.js'
+import { lookupCommand, lookupOptions } from './lookup_command.js'
 import { createRegistry } from './registry.js'
 import { state } from './state.js'
 import type { z } from './zod.js'
@@ -63,7 +64,8 @@ export function builder(context: Context, options: cli.Options): cli.Builder & c
 		await Promise.all(pending)
 		context.ui.debug('argv:', argv.join(' '))
 		const rawArgs = parseArgv(argv)
-		const { args: baseArgs } = lookupCommand(getBaseCommand(s.description, { config: !!s.configName }), rawArgs)
+		const baseCommand = getBaseCommand(s.description, { config: !!s.configName })
+		const { args: baseArgs } = lookupCommand(baseCommand, rawArgs)
 		if (baseArgs.silent) {
 			delete rawArgs.silent
 			s.displayLevel = 'none'
@@ -84,8 +86,20 @@ export function builder(context: Context, options: cli.Options): cli.Builder & c
 		const r = lookupCommand(s.command, rawArgs)
 		const { args, command } = r
 
-		if (args.version) return createCommandInstance(context, s, r.command, registry).ui.showVersion()
-		if (r.errors.length > 0) return createCommandInstance(context, s, r.command, registry).ui.showHelp()
+		if (baseArgs.version || args.version) return createCommandInstance(context, s, r.command, registry).ui.showVersion()
+		// `--help` is answered before the errors are reported: it is the one flag
+		// that is always valid, and asking for help is not a usage error.
+		if (baseArgs.help || args.help) return createCommandInstance(context, s, r.command, registry).ui.showHelp()
+
+		// the global options live on the base command, so a sub command that declares
+		// no options of its own reports them as unknown. They are always accepted.
+		const errors = r.errors.filter((e) => !(e.type === 'invalid-key' && !!lookupOptions(baseCommand, e.key)[0]))
+		if (errors.length > 0) {
+			const ui = createCommandInstance(context, s, r.command, registry).ui
+			for (const e of errors) ui.error(formatLookupError(e, command))
+			ui.showHelp()
+			return context.exit(exitCodes.usage)
+		}
 
 		if (command.config) {
 			const configName = typeof s.configName === 'string' ? s.configName : s.name
@@ -96,13 +110,22 @@ export function builder(context: Context, options: cli.Options): cli.Builder & c
 				context.ui.error('config fails validation:')
 				forEachKey(errors, (k) => context.ui.error(`  ${String(k)}: ${errors[k]}`))
 				createCommandInstance(context, s, r.command, registry).ui.showHelp()
-				return
+				return context.exit(exitCodes.error)
 			}
 			s.config = config
 		}
 		const commandInstance = createCommandInstance(context, s, command, registry)
-		if (!commandInstance.run || args.help) return commandInstance.ui.showHelp()
-		return commandInstance.run(args as any)
+		if (!commandInstance.run) return commandInstance.ui.showHelp()
+		try {
+			return await commandInstance.run(args as any)
+		} catch (e) {
+			// a command signals failure by throwing `CliError`. Anything else is a
+			// defect in the command and keeps propagating to the caller.
+			if (!isCliError(e)) throw e
+			commandInstance.ui.error(e.message)
+			for (const h of e.help) commandInstance.ui.error(h)
+			return context.exit(e.exitCode)
+		}
 	}
 
 	/**

--- a/packages/clibuilder/ts/context.mock.ts
+++ b/packages/clibuilder/ts/context.mock.ts
@@ -13,10 +13,13 @@ export namespace mockContext {
 	export type Params = { fixtureDir?: string; logLevel?: LogLevel }
 }
 
-export function mockContext(params?: mockContext.Params): Context & { sl: StandardLogForTest } {
+export function mockContext(
+	params?: mockContext.Params
+): Context & { sl: StandardLogForTest; readonly exitCode: number | undefined } {
 	const { fixtureDir, logLevel } = required({ logLevel: logLevels.debug }, params)
 	const cwd = fixtureDir ? getFixturePath(fixtureDir) : tmp.dirSync().name
 	const sl = createStandardLogForTest({ logLevel })
+	let exitCode: number | undefined
 	return {
 		async loadConfig(configName: string) {
 			return (await this.resolveConfig(configName)).config
@@ -28,10 +31,18 @@ export function mockContext(params?: mockContext.Params): Context & { sl: Standa
 			return loadPlugins({ cwd, ui: this.ui, registry, host }, pluginNames)
 		},
 		cwd,
+		/**
+		 * Records the code instead of touching `process.exitCode`,
+		 * so a test can assert the cli failed without failing the test run.
+		 * It is also reported through `ui` so the exit shows up in the log messages.
+		 */
 		exit: function (this: any, code?: number) {
-			// istanbul ignore next
+			exitCode = code
 			this.ui.error(code === undefined ? 'exit' : `exit with ${code}`)
 		} as any,
+		get exitCode() {
+			return exitCode
+		},
 		createCommandUI(id: string) {
 			return createUI(sl.getLogger(id))
 		},

--- a/packages/clibuilder/ts/context.spec.ts
+++ b/packages/clibuilder/ts/context.spec.ts
@@ -1,0 +1,20 @@
+import { context } from './context.js'
+
+describe('exit()', () => {
+	// the code is recorded on `process` rather than acted on immediately,
+	// so it is restored here to leave this test run's own exit code alone.
+	const original = process.exitCode
+	afterEach(() => {
+		process.exitCode = original
+	})
+
+	it('records the code the process should exit with', () => {
+		context().exit(2)
+		expect(process.exitCode).toBe(2)
+	})
+
+	it('does not end the process', () => {
+		context().exit(1)
+		expect(true).toBe(true)
+	})
+})

--- a/packages/clibuilder/ts/context.ts
+++ b/packages/clibuilder/ts/context.ts
@@ -40,7 +40,16 @@ export function context() {
 			return (loadingCommands = loadPlugins({ cwd, ui: this.ui, registry, host }, pluginNames))
 		},
 		cwd,
-		exit: process.exit,
+		/**
+		 * Records the code the process should exit with.
+		 *
+		 * `process.exit()` would end the process on the spot and truncate whatever
+		 * is still buffered on stdout, so the code is recorded instead and node
+		 * exits with it once the cli is done and the event loop drains.
+		 */
+		exit(code?: number) {
+			process.exitCode = code
+		},
 		createCommandUI(id: string) {
 			return createUI(sl.getLogger(id))
 		},

--- a/packages/clibuilder/ts/errors.spec.ts
+++ b/packages/clibuilder/ts/errors.spec.ts
@@ -1,0 +1,111 @@
+import { CliError, exitCodes, formatLookupError, isCliError } from './errors.js'
+import { command, z } from './index.js'
+
+describe('exitCodes', () => {
+	it('follows the AXI convention', () => {
+		expect(exitCodes).toEqual({ success: 0, error: 1, usage: 2 })
+	})
+})
+
+describe('CliError', () => {
+	it('defaults to the generic error code', () => {
+		const err = new CliError('boom')
+		expect(err.message).toBe('boom')
+		expect(err.exitCode).toBe(exitCodes.error)
+		expect(err.help).toEqual([])
+	})
+	it('accepts an exit code', () => {
+		expect(new CliError('boom', { exitCode: exitCodes.usage }).exitCode).toBe(2)
+	})
+	it('accepts a single help line', () => {
+		expect(new CliError('boom', { help: 'try this' }).help).toEqual(['try this'])
+	})
+	it('accepts multiple help lines', () => {
+		expect(new CliError('boom', { help: ['a', 'b'] }).help).toEqual(['a', 'b'])
+	})
+	it('is an Error', () => {
+		const err = new CliError('boom')
+		expect(err).toBeInstanceOf(Error)
+		expect(err.name).toBe('CliError')
+		expect(err.stack).toBeDefined()
+	})
+	it('keeps the cause', () => {
+		const cause = new Error('inner')
+		expect(new CliError('boom', { cause }).cause).toBe(cause)
+	})
+})
+
+describe('isCliError()', () => {
+	it('recognizes a CliError', () => {
+		expect(isCliError(new CliError('boom'))).toBe(true)
+	})
+	it('recognizes a CliError from another copy of clibuilder', () => {
+		// a duplicated `clibuilder` in the dependency tree means `instanceof` fails,
+		// so the check is on the brand, not the prototype chain.
+		const foreign = Object.assign(new Error('boom'), {
+			[Symbol.for('clibuilder.CliError')]: true,
+			exitCode: 2,
+			help: []
+		})
+		expect(isCliError(foreign)).toBe(true)
+	})
+	it('rejects a plain error', () => {
+		expect(isCliError(new Error('boom'))).toBe(false)
+	})
+	it('rejects a non-error', () => {
+		expect(isCliError(undefined)).toBe(false)
+		expect(isCliError('boom')).toBe(false)
+	})
+})
+
+describe('formatLookupError()', () => {
+	const cmd = command({
+		name: 'cmd',
+		arguments: [{ name: 'arg', description: 'an arg', type: z.number() }],
+		options: { abc: { description: 'abc', type: z.optional(z.number()) } },
+		run() {}
+	})
+
+	it('names an unknown option', () => {
+		expect(formatLookupError({ type: 'invalid-key', key: 'bogus' }, cmd)).toBe('unknown option --bogus')
+	})
+	it('names an unknown single character option with one dash', () => {
+		expect(formatLookupError({ type: 'invalid-key', key: 'x' }, cmd)).toBe('unknown option -x')
+	})
+	it('leaves an already dashed key alone', () => {
+		expect(formatLookupError({ type: 'invalid-key', key: '-help' }, cmd)).toBe('unknown option ---help')
+	})
+	it('names a missing argument', () => {
+		expect(formatLookupError({ type: 'missing-argument', name: 'arg' }, cmd)).toBe('missing required argument <arg>')
+	})
+	it('names one extra argument', () => {
+		expect(formatLookupError({ type: 'extra-arguments', name: 'cmd', values: ['x'] }, cmd)).toBe(
+			'unexpected argument: x'
+		)
+	})
+	it('names every extra argument', () => {
+		expect(formatLookupError({ type: 'extra-arguments', name: 'cmd', values: ['x', 'y'] }, cmd)).toBe(
+			'unexpected arguments: x, y'
+		)
+	})
+	it('names an invalid option value', () => {
+		expect(
+			formatLookupError({ type: 'invalid-value', key: 'abc', value: 'xyz', message: 'expected to be number' }, cmd)
+		).toBe('invalid value for option --abc: expected to be number, received "xyz"')
+	})
+	it('names an invalid argument value', () => {
+		expect(
+			formatLookupError({ type: 'invalid-value', key: 'arg', value: 'xyz', message: 'expected to be number' }, cmd)
+		).toBe('invalid value for argument <arg>: expected to be number, received "xyz"')
+	})
+	it('names an option given too many values', () => {
+		expect(formatLookupError({ type: 'expect-single', key: 'abc', keyType: z.number(), value: ['1', '2'] }, cmd)).toBe(
+			'option --abc expects a single value, received: 1, 2'
+		)
+	})
+	it('reports a single value for an option given too many values', () => {
+		expect(formatLookupError({ type: 'expect-single', key: 'abc', keyType: z.number(), value: '1' }, cmd)).toBe(
+			'option --abc expects a single value, received: 1'
+		)
+	})
+})

--- a/packages/clibuilder/ts/errors.ts
+++ b/packages/clibuilder/ts/errors.ts
@@ -1,0 +1,125 @@
+import type { cli } from './cli.js'
+import type { lookupCommand } from './lookup_command.js'
+
+/**
+ * The exit codes a clibuilder cli uses.
+ *
+ * They follow the AXI (Agent eXperience Interface) convention so an agent
+ * driving the cli through a shell can tell the three cases apart:
+ * the command did what was asked, the command failed, or the command was
+ * called wrong and should be called again differently.
+ */
+export const exitCodes = {
+	/**
+	 * The command did what was asked, including no-ops.
+	 */
+	success: 0,
+	/**
+	 * The command was called correctly but could not complete.
+	 */
+	error: 1,
+	/**
+	 * The command was called incorrectly: an unknown option, a missing
+	 * argument, a value of the wrong type. Retrying the same invocation
+	 * cannot help.
+	 */
+	usage: 2
+} as const
+
+const cliErrorBrand: unique symbol = Symbol.for('clibuilder.CliError')
+
+export namespace CliError {
+	export type Options = {
+		/**
+		 * The code the cli exits with. Defaults to `exitCodes.error` (1).
+		 * Use `exitCodes.usage` (2) when the invocation itself was wrong.
+		 */
+		exitCode?: number
+		/**
+		 * What the caller should do about it.
+		 * Printed after the message, one line each.
+		 */
+		help?: string | string[]
+		cause?: unknown
+	}
+}
+
+/**
+ * Throw this from a command's `run()` to fail the cli.
+ *
+ * The message and the help lines are printed through the command's `ui`,
+ * and the cli exits with `exitCode`. `parse()` resolves to `undefined`
+ * instead of rejecting, so the failure is reported rather than surfacing
+ * as an unhandled rejection with a stack trace.
+ *
+ * @example
+ * ```ts
+ * run({ field }) {
+ * 	if (!fields.includes(field)) {
+ * 		throw new CliError(`unknown field "${field}"`, {
+ * 			exitCode: exitCodes.usage,
+ * 			help: `valid fields: ${fields.join(', ')}`
+ * 		})
+ * 	}
+ * }
+ * ```
+ */
+export class CliError extends Error {
+	override readonly name = 'CliError'
+	readonly exitCode: number
+	readonly help: string[]
+	/**
+	 * The error this one wraps, if any.
+	 * Declared here rather than taken from `ErrorOptions` to keep the
+	 * package compiling against its `ES2020` target.
+	 */
+	readonly cause?: unknown
+	// branded so the check survives a duplicated `clibuilder` in the
+	// dependency tree, where `instanceof` compares two different classes.
+	readonly [cliErrorBrand] = true
+
+	constructor(message: string, options?: CliError.Options) {
+		super(message)
+		this.exitCode = options?.exitCode ?? exitCodes.error
+		this.help = options?.help === undefined ? [] : Array.isArray(options.help) ? options.help : [options.help]
+		this.cause = options?.cause
+	}
+}
+
+export function isCliError(err: unknown): err is CliError {
+	return !!err && typeof err === 'object' && (err as any)[cliErrorBrand] === true
+}
+
+/**
+ * Describes one `lookupCommand` error in the terms the caller used:
+ * which option or argument was wrong, and what was expected.
+ *
+ * @param command the command the error was found on, used to tell an
+ * argument name apart from an option name.
+ */
+export function formatLookupError(error: lookupCommand.Error, command: cli.Command): string {
+	switch (error.type) {
+		case 'invalid-key':
+			return `unknown option ${formatOption(error.key)}`
+		case 'missing-argument':
+			return `missing required argument <${error.name}>`
+		case 'extra-arguments':
+			return `unexpected argument${error.values.length > 1 ? 's' : ''}: ${error.values.join(', ')}`
+		case 'invalid-value':
+			return `invalid value for ${formatKey(error.key, command)}: ${error.message}, received "${error.value}"`
+		case 'expect-single':
+			return `${formatKey(error.key, command)} expects a single value, received: ${toArray(error.value).join(', ')}`
+	}
+}
+
+function formatKey(key: string, command: cli.Command) {
+	return command.arguments?.some((a) => a.name === key) ? `argument <${key}>` : `option ${formatOption(key)}`
+}
+
+function formatOption(key: string) {
+	return key.length === 1 ? `-${key}` : `--${key}`
+}
+
+function toArray(value: any) {
+	return Array.isArray(value) ? value : [value]
+}

--- a/packages/clibuilder/ts/index.ts
+++ b/packages/clibuilder/ts/index.ts
@@ -14,6 +14,7 @@ export {
 	readConfigFile,
 	resolveConfig
 } from './config.js'
+export { CliError, exitCodes, isCliError } from './errors.js'
 export * from './registry.js'
 export * from './testing/test_command.js'
 export * from './zod.js'

--- a/packages/clibuilder/ts/lookup_command.ts
+++ b/packages/clibuilder/ts/lookup_command.ts
@@ -142,7 +142,11 @@ function fillDefaultOptions(state: State) {
 	)
 }
 
-function lookupOptions(command: cli.Command, key: string): [string, cli.Command.Options.Entry] | [] {
+/**
+ * Finds the option a key refers to, by name or by alias.
+ * Returns an empty tuple when the command declares no such option.
+ */
+export function lookupOptions(command: cli.Command, key: string): [string, cli.Command.Options.Entry] | [] {
 	const opts = command.options
 	if (!opts) return []
 	const options = opts[key]

--- a/packages/clibuilder/ts/testing/test_cmmand.spec.ts
+++ b/packages/clibuilder/ts/testing/test_cmmand.spec.ts
@@ -1,4 +1,4 @@
-import { command, testCommand } from '../index.js'
+import { CliError, command, exitCodes, testCommand } from '../index.js'
 
 test('get result', async () => {
 	const { result } = await testCommand(
@@ -24,4 +24,44 @@ test('get messages', async () => {
 		'cmd'
 	)
 	expect(messages).toBe('hello')
+})
+
+test('get no exit code when the command succeeds', async () => {
+	const { exitCode } = await testCommand(
+		command({
+			name: 'cmd',
+			run() {}
+		}),
+		'cmd'
+	)
+	expect(exitCode).toBeUndefined()
+})
+
+test('get the exit code of a failing command', async () => {
+	const { exitCode, messages } = await testCommand(
+		command({
+			name: 'cmd',
+			run() {
+				throw new CliError('nope', { exitCode: exitCodes.usage, help: 'try `cmd --help`' })
+			}
+		}),
+		'cmd'
+	)
+	expect(exitCode).toBe(2)
+	expect(messages).toContain('nope')
+	expect(messages).toContain('try `cmd --help`')
+})
+
+test('get the exit code of a usage error', async () => {
+	const { exitCode, messages } = await testCommand(
+		command({
+			name: 'cmd',
+			run() {
+				throw new Error('should not reach')
+			}
+		}),
+		'cmd --bogus'
+	)
+	expect(exitCode).toBe(2)
+	expect(messages).toContain('unknown option --bogus')
 })

--- a/packages/clibuilder/ts/testing/test_command.ts
+++ b/packages/clibuilder/ts/testing/test_command.ts
@@ -12,5 +12,6 @@ export async function testCommand(command: cli.Command, argv: string, config?: R
 		.command(command)
 		.parse(tu.argv(`test-cli ${argv}`))
 	const messages = ctx.sl.reporter.getLogMessage()
-	return { result, messages }
+	// `undefined` when the command did not fail, matching a process that exits 0.
+	return { result, messages, exitCode: ctx.exitCode }
 }


### PR DESCRIPTION
## Problem

No clibuilder cli could ever report a non-zero exit code, and usage errors were silently swallowed.

`lookup_command.ts` already builds a typed `errors: lookupCommand.Error[]` — `invalid-key`, `missing-argument`, `extra-arguments`, `expect-single`, value-conversion failures — and `builder.ts` threw the whole array away:

```ts
if (r.errors.length > 0) return createCommandInstance(...).ui.showHelp()
```

So an agent that typos a flag got a full manual that never named the offending flag, and an exit code of `0`. A command that *knew* it had failed had no route out either: `context.exit` existed but was never called by anything.

## What changed

- **Usage errors are named**, one line each, ahead of the help message, and the cli exits `2`:
  ```
  $ test-cli --bogus
  unknown option --bogus

  Usage: test-cli <command> [options]
  ...
  ```
  Every error found is reported, not just the first. `invalid-value` and `expect-single` distinguish an option (`option --abc`) from an argument (`argument <arg>`).
- **A command fails by throwing `CliError`** — new export, carrying `exitCode` (default 1) and optional `help` lines. `builder` catches it, prints it through the command's `ui`, and records the code. Anything else thrown keeps propagating: a defect is not a reported failure.
- **New exports**: `CliError`, `exitCodes` (`success`/`error`/`usage` = 0/1/2), `isCliError()` (brand-based, so it survives a duplicated `clibuilder` in the dep tree).
- **`process.exitCode`, not `process.exit()`** — `process.exit()` truncates pending stdout writes; the code is recorded and node exits with it once the cli is done.
- **A config that fails its schema exits `1`** (it was `0`).
- **`--help` / `--version` answer on every command**, including sub-commands that declare no options of their own. They live on the base command, so `test-cli cmd -h` used to be an `invalid-key` error that happened to print help — which would now have been reported as a usage error. `--help` is answered before errors are reported: asking for help is not a usage error, and both still exit `0`.
- **`testCommand()` returns `exitCode`** alongside `result` and `messages`. `mockContext` records the code instead of touching `process`, and still reports it through `ui.error` as before, so a test can assert a failure without ending the test run.

Exit codes follow the AXI convention (`0` success incl. no-ops, `1` error, `2` usage error), as specified in the `axi` skill §6.

## Out of scope

Kept to exit codes and surfacing the typed errors. Untouched, from the earlier AXI audit: errors going to stderr rather than stdout, `plugins list` prose + AND-matching, `--show-config` raw JSON, no home view. The error lines therefore go through `ui.error` in the repo's existing style (no `error:` prefix) — the channel and format overhaul is a separate change.

## Versioning — for the Council

Changeset says **minor**, and I want that judged rather than assumed. The TypeScript surface is purely additive, but every cli built on clibuilder changes behavior: an invocation with a typo used to exit `0` and now exits `2`, which can break a caller downstream of *your* cli that ignored the code. The break lands one hop removed from clibuilder's own consumers. clibuilder is freshly at 10.0.0, so a major is cheap if the Council prefers it.

## Verification

`pnpm verify` green (lint + build + coverage + depcheck + size), 333 tests. `pnpm web typecheck` green. End-to-end on `test-apps/test-cli`: `--bogus` → 2, `echo hi` → 0, `echo --help` → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)