### PR TITLE
chore(repo): add `cli` and `cli:esm` scripts to poke at a real cli

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,27 @@
 # Contributing
 
+## Poking at a real CLI
+
+To try a change by hand, run one of the dummy CLIs in [`test-apps`](./test-apps):
+
+```sh
+pnpm cli --help                    # test-apps/test-cli (CJS)
+pnpm cli echo hi
+pnpm cli plugins list --format json
+pnpm cli:esm --help                # test-apps/test-cli-esm (ESM)
+```
+
+Both scripts build `clibuilder` first (a warm `turbo` cache makes that ~0.1s),
+so the workspace symlink always resolves to fresh output.
+
+Arguments pass straight through — `pnpm` does not swallow `--help`, and no `--`
+separator is needed. The build's own output goes to `stderr`, so the CLI's
+`stdout` stays clean for piping; add `-s` to drop the `pnpm` banner too:
+
+```sh
+pnpm -s cli plugins list --format json | jq .plugins
+```
+
 ## `clibuilder` dev dependencies
 
 The `clibuilder` package adds the test plugins as its `devDependencies`.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
 		"build": "turbo run build",
 		"check": "biome check",
 		"check:fix": "biome check --fix",
+		"cli": "turbo run build --filter=clibuilder --output-logs=errors-only 1>&2 && node test-apps/test-cli/bin.js",
+		"cli:esm": "turbo run build --filter=clibuilder --output-logs=errors-only 1>&2 && node test-apps/test-cli-esm/bin.mjs",
 		"clean": "turbo run clean",
 		"clibuilder": "pnpm --filter clibuilder",
 		"coverage": "turbo run coverage",

--- a/test-apps/test-cli-esm/bin.mjs
+++ b/test-apps/test-cli-esm/bin.mjs
@@ -8,7 +8,10 @@ const { cli } = await import('clibuilder')
 
 const app = cli({
 	name: 'test-cli',
-	version: '1.0.0'
+	version: '1.0.0',
+	// enables the built-in `plugins` command, so `pnpm cli plugins list` and
+	// `pnpm cli plugins search` are reachable by hand.
+	keywords: ['test-cli']
 })
 	.default({
 		run() {

--- a/test-apps/test-cli/bin.js
+++ b/test-apps/test-cli/bin.js
@@ -4,7 +4,10 @@ const { cli } = require('clibuilder')
 
 const app = cli({
 	name: 'test-cli',
-	version: '1.0.0'
+	version: '1.0.0',
+	// enables the built-in `plugins` command, so `pnpm cli plugins list` and
+	// `pnpm cli plugins search` are reachable by hand.
+	keywords: ['test-cli']
 })
 	.default({
 		run() {

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
 		"build": {
 			"dependsOn": ["^build"],
 			"inputs": ["package.json", "tsconfig.*", "ts/**/*.tsx?", "src/**/*.tsx?"],
-			"outputs": ["esm/**"]
+			"outputs": ["cjs/**", "esm/**"]
 		},
 		"clean": {
 			"cache": false


### PR DESCRIPTION
## What

Two root dev scripts for hands-on testing, so trying a change no longer needs a scratch file:

| script | runs |
| --- | --- |
| `pnpm cli` | `turbo run build --filter=clibuilder` then `node test-apps/test-cli/bin.js` (CJS) |
| `pnpm cli:esm` | same build, then `node test-apps/test-cli-esm/bin.mjs` (ESM) |

No new dummy cli — these are the two that already existed.

## Build first, not fail-clearly

`bin.js` requires `clibuilder` through the workspace symlink, so unbuilt output gives a raw
`MODULE_NOT_FOUND`. The scripts build first: a warm turbo cache costs ~0.1s, cheaper than
asking a human to notice a message and re-run. Building also means you never poke at a stale build.

That exposed a real gap — `turbo.json` declared only `esm/**` as a build output, so a cache hit
restored the ESM build and left `cjs/` missing, breaking exactly the CJS path this script uses.
Fixed in its own commit (`cjs/**` added to `outputs`).

## Pass-through

`pnpm` does not swallow flags here; no `--` needed. Verified:

- `pnpm cli --help` → the cli's help, not pnpm's
- `pnpm cli echo hi` → `echoing: hi`
- `pnpm cli plugins list --format json` → `{ "plugins": [] }`
- `pnpm cli` → the default command's error + info lines
- `pnpm cli --version` → `1.0.0`
- same for `pnpm cli:esm`

The build's output is redirected to stderr, so the cli's stdout stays clean:
`pnpm -s cli plugins list --format json | jq .plugins` → `[]`.

## Fixture change

Both fixtures gained `keywords: ['test-cli']`, which turns on clibuilder's built-in `plugins`
command. Nothing existing was edited — `echo`, `config-value` and the default command are untouched.

## Docs

A "Poking at a real CLI" section in `CONTRIBUTING.md`.

## No changeset

Root `package.json` is private and `packages/**` is untouched, so nothing published changes.

`pnpm verify` is green (362 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)